### PR TITLE
docs(api-reference): fix TV series list links

### DIFF
--- a/apps/docs/content/docs/api-reference/tv-series-lists/index.mdx
+++ b/apps/docs/content/docs/api-reference/tv-series-lists/index.mdx
@@ -15,7 +15,7 @@ const { results } = await tmdb.tvSeriesLists.popular();
 
 ## Methods
 
-- [`airing_today()`](/docs/api-reference/tv-series/lists/airing-today) — Get TV shows airing today.
-- [`on_the_air()`](/docs/api-reference/tv-series/lists/on-the-air) — Get TV shows airing in the next 7 days.
-- [`popular()`](/docs/api-reference/tv-series/lists/popular) — Get TV shows ordered by popularity.
-- [`top_rated()`](/docs/api-reference/tv-series/lists/top-rated) — Get TV shows ordered by rating.
+- [`airing_today()`](/docs/api-reference/tv-series-lists/airing-today) — Get TV shows airing today.
+- [`on_the_air()`](/docs/api-reference/tv-series-lists/on-the-air) — Get TV shows airing in the next 7 days.
+- [`popular()`](/docs/api-reference/tv-series-lists/popular) — Get TV shows ordered by popularity.
+- [`top_rated()`](/docs/api-reference/tv-series-lists/top-rated) — Get TV shows ordered by rating.

--- a/apps/docs/content/docs/types/tv-series.mdx
+++ b/apps/docs/content/docs/types/tv-series.mdx
@@ -237,7 +237,7 @@ A [`PaginatedResponse`](/docs/types/common#paginatedresponset) of [`TVSeriesList
 
 ### `TVSeriesListParams`
 
-Used by [`airing_today()`](/docs/api-reference/tv-series/lists/airing-today), [`on_the_air()`](/docs/api-reference/tv-series/lists/on-the-air), [`popular()`](/docs/api-reference/tv-series/lists/popular), and [`top_rated()`](/docs/api-reference/tv-series/lists/top-rated).
+Used by [`airing_today()`](/docs/api-reference/tv-series-lists/airing-today), [`on_the_air()`](/docs/api-reference/tv-series-lists/on-the-air), [`popular()`](/docs/api-reference/tv-series-lists/popular), and [`top_rated()`](/docs/api-reference/tv-series-lists/top-rated).
 
 <TypeTable
 	type={{


### PR DESCRIPTION
Fix the TV Series Lists docs links to use the tv-series-lists route instead of the tv-series/lists endpoint path.

This updates the TV Series Lists API page and the related type docs so the method links resolve to the correct docs pages instead of 404ing.

Fixes #59