### PR TITLE
feat(people): add people api support

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ The SDK is organized into modular namespaces that mirror TMDB's API structure. E
 You can instantiate single API modules or use the full client for all features. Available namespaces include:
 
 - `tmdb.movies` - Movie-related endpoints (details, credits, images, etc.)
+- `tmdb.people` - Person-related endpoints (details, credits, images, translations, and external IDs)
 - `tmdb.tv_series` - TV series endpoints (details, credits, episode groups, etc.)
 - `tmdb.search` - Search endpoints for movies, TV shows, people, etc.
 - `tmdb.lists` - User-created lists and TMDB-curated lists.
@@ -174,7 +175,7 @@ Planned features and improvements include:
 | Movies            | ✅     |
 | Networks          | ✅     |
 | People Lists      | ✅     |
-| People            | ❌     |
+| People            | ✅     |
 | Reviews           | ✅     |
 | Search            | ✅     |
 | Trending          | ✅     |

--- a/apps/docs/content/docs/api-reference/index.mdx
+++ b/apps/docs/content/docs/api-reference/index.mdx
@@ -78,6 +78,7 @@ const airingToday = await tvApi.airingToday();
 | [Genres](/docs/api-reference/genres)                       | `tmdb.genres`            | `GenresAPI`          | Fetch the list of official movie and TV series genres.                             |
 | [Movie Lists](/docs/api-reference/movie-lists)             | `tmdb.movieLists`        | `MovieListsAPI`      | Access curated movie lists: popular, top rated, now playing, and upcoming.         |
 | [Movies](/docs/api-reference/movies)                       | `tmdb.movies`            | `MoviesAPI`          | Get movie details, credits, images, videos, recommendations, and more.             |
+| [People](/docs/api-reference/people)                       | `tmdb.people`            | `PeopleAPI`          | Get person details, credits, images, translations, and external IDs.                |
 | [People Lists](/docs/api-reference/people-lists)           | `tmdb.people_lists`      | `PeopleListsAPI`     | Get curated lists of people ordered by popularity.                                 |
 | [Search](/docs/api-reference/search)                       | `tmdb.search`            | `SearchAPI`          | Search for movies, TV series, people, and keywords across the TMDB catalog.        |
 | [Trending](/docs/api-reference/trending)                   | `tmdb.trending`          | `TrendingAPI`        | Get trending movies, TV series, and people on TMDB.                                |

--- a/apps/docs/content/docs/api-reference/people/changes.mdx
+++ b/apps/docs/content/docs/api-reference/people/changes.mdx
@@ -1,0 +1,40 @@
+---
+title: Changes
+description: Query the change history for a specific person.
+---
+
+Returns the changes made to a person record. By default, TMDB returns the last 24 hours of changes.
+
+```ts
+async changes(params: PersonChangesParams): Promise<PersonChanges>
+```
+
+> **TMDB Reference:** [Person Changes](https://developer.themoviedb.org/reference/person-changes)
+
+## Parameters
+
+| Name         | Type     | Required | Description                                             |
+| ------------ | -------- | -------- | ------------------------------------------------------- |
+| `person_id`  | `number` | ✅       | TMDB person identifier.                                 |
+| `page`       | `number` | ❌       | Page number for paginated change results.               |
+| `start_date` | `string` | ❌       | Start date in `YYYY-MM-DD` format.                      |
+| `end_date`   | `string` | ❌       | End date in `YYYY-MM-DD` format.                        |
+
+## Returns
+
+A [`PersonChanges`](/docs/types/people#personchanges) object containing grouped changes.
+
+## Example
+
+```ts
+const changes = await tmdb.people.changes({
+	person_id: 31,
+	start_date: "2024-01-01",
+	end_date: "2024-01-14",
+});
+```
+
+## Related Types
+
+- [`PersonChanges`](/docs/types/people#personchanges)
+- [`PersonChangesParams`](/docs/types/people#personchangesparams)

--- a/apps/docs/content/docs/api-reference/people/combined-credits.mdx
+++ b/apps/docs/content/docs/api-reference/people/combined-credits.mdx
@@ -1,0 +1,33 @@
+---
+title: Combined Credits
+description: Query both movie and TV cast and crew credits for a person.
+---
+
+```ts
+async combined_credits(params: PersonCreditsParams): Promise<PersonCombinedCredits>
+```
+
+> **TMDB Reference:** [Person Combined Credits](https://developer.themoviedb.org/reference/person-combined-credits)
+
+## Parameters
+
+| Name        | Type                                                | Required | Description                                          |
+| ----------- | --------------------------------------------------- | -------- | ---------------------------------------------------- |
+| `person_id` | `number`                                            | ✅       | TMDB person identifier.                              |
+| `language`  | [`Language`](/docs/types/options/language#language) | ❌       | Language for localized results. Defaults to `en-US`. |
+
+## Returns
+
+A [`PersonCombinedCredits`](/docs/types/people#personcombinedcredits) object containing both movie and TV credits.
+
+## Example
+
+```ts
+const credits = await tmdb.people.combined_credits({ person_id: 31 });
+console.log(credits.cast.length, credits.crew.length);
+```
+
+## Related Types
+
+- [`PersonCombinedCredits`](/docs/types/people#personcombinedcredits)
+- [`PersonCreditsParams`](/docs/types/people#personcreditsparams)

--- a/apps/docs/content/docs/api-reference/people/details.mdx
+++ b/apps/docs/content/docs/api-reference/people/details.mdx
@@ -1,0 +1,43 @@
+---
+title: Details
+description: Query the top-level details of a person.
+---
+
+```ts
+async details(params: PersonDetailsParams): Promise<PersonDetails>
+```
+
+> **TMDB Reference:** [Person Details](https://developer.themoviedb.org/reference/person-details)
+
+## Parameters
+
+| Name                 | Type                                                                 | Required | Description                                                                 |
+| -------------------- | -------------------------------------------------------------------- | -------- | --------------------------------------------------------------------------- |
+| `person_id`          | `number`                                                             | ✅       | TMDB person identifier.                                                     |
+| `language`           | [`Language`](/docs/types/options/language#language)                  | ❌       | Language for localized results. Defaults to `en-US`.                       |
+| `append_to_response` | `PersonAppendToResponseNamespace \| PersonAppendToResponseNamespace[]` | ❌       | Subresources to append to the main person details response.                 |
+
+## Returns
+
+A [`PersonDetails`](/docs/types/people#persondetails) object containing the person's profile.
+When `append_to_response` is used, the response also includes the appended subresource payloads.
+
+## Example
+
+```ts
+import { TMDB } from "@lorenzopant/tmdb";
+
+const tmdb = new TMDB("your-api-key");
+
+const person = await tmdb.people.details({ person_id: 31 });
+
+const withExtras = await tmdb.people.details({
+	person_id: 31,
+	append_to_response: ["images", "external_ids", "movie_credits"],
+});
+```
+
+## Related Types
+
+- [`PersonDetails`](/docs/types/people#persondetails)
+- [`PersonDetailsParams`](/docs/types/people#persondetailsparams)

--- a/apps/docs/content/docs/api-reference/people/external-ids.mdx
+++ b/apps/docs/content/docs/api-reference/people/external-ids.mdx
@@ -1,0 +1,32 @@
+---
+title: External IDs
+description: Query the external platform identifiers associated with a person.
+---
+
+```ts
+async external_ids(params: PersonExternalIDsParams): Promise<PersonExternalIDs>
+```
+
+> **TMDB Reference:** [Person External IDs](https://developer.themoviedb.org/reference/person-external-ids)
+
+## Parameters
+
+| Name        | Type     | Required | Description              |
+| ----------- | -------- | -------- | ------------------------ |
+| `person_id` | `number` | ✅       | TMDB person identifier.  |
+
+## Returns
+
+A [`PersonExternalIDs`](/docs/types/people#personexternalids) object containing linked platform identifiers.
+
+## Example
+
+```ts
+const ids = await tmdb.people.external_ids({ person_id: 31 });
+console.log(ids.imdb_id);
+```
+
+## Related Types
+
+- [`PersonExternalIDs`](/docs/types/people#personexternalids)
+- [`PersonExternalIDsParams`](/docs/types/people#personexternalidsparams)

--- a/apps/docs/content/docs/api-reference/people/images.mdx
+++ b/apps/docs/content/docs/api-reference/people/images.mdx
@@ -1,0 +1,35 @@
+---
+title: Images
+description: Query the profile images associated with a person.
+---
+
+This endpoint returns the profile images for a person. Unlike some movie and TV image endpoints,
+the official TMDB OpenAPI contract does not expose language filtering for person images.
+
+```ts
+async images(params: PersonImagesParams): Promise<PersonImages>
+```
+
+> **TMDB Reference:** [Person Images](https://developer.themoviedb.org/reference/person-images)
+
+## Parameters
+
+| Name        | Type     | Required | Description              |
+| ----------- | -------- | -------- | ------------------------ |
+| `person_id` | `number` | ✅       | TMDB person identifier.  |
+
+## Returns
+
+A [`PersonImages`](/docs/types/people#personimages) object containing the person's profile images.
+
+## Example
+
+```ts
+const images = await tmdb.people.images({ person_id: 31 });
+console.log(images.profiles.length);
+```
+
+## Related Types
+
+- [`PersonImages`](/docs/types/people#personimages)
+- [`PersonImagesParams`](/docs/types/people#personimagesparams)

--- a/apps/docs/content/docs/api-reference/people/index.mdx
+++ b/apps/docs/content/docs/api-reference/people/index.mdx
@@ -1,0 +1,30 @@
+---
+title: People
+description: Retrieve person details, credits, images, translations, and external IDs from TMDB.
+---
+
+The `PeopleAPI` provides access to person-specific TMDB resources such as top-level details,
+credits, images, translations, and tagged images.
+
+```ts
+import { TMDB } from "@lorenzopant/tmdb";
+
+const tmdb = new TMDB("your-api-key");
+const person = await tmdb.people.details({ person_id: 31 });
+```
+
+For curated person lists, use [`tmdb.people_lists`](/docs/api-reference/people-lists).
+For global person changes, use [`tmdb.changes.people_list()`](/docs/api-reference/changes/people-list).
+
+## Methods
+
+- [`details()`](/docs/api-reference/people/details) — Get the top-level details of a person by ID. Supports `append_to_response`.
+- [`changes()`](/docs/api-reference/people/changes) — Get the change history for a person.
+- [`combined_credits()`](/docs/api-reference/people/combined-credits) — Get movie and TV cast/crew credits in one response.
+- [`external_ids()`](/docs/api-reference/people/external-ids) — Get external platform identifiers for a person.
+- [`images()`](/docs/api-reference/people/images) — Get profile images for a person.
+- [`latest()`](/docs/api-reference/people/latest) — Get the most recently added person on TMDB.
+- [`movie_credits()`](/docs/api-reference/people/movie-credits) — Get movie cast and crew credits for a person.
+- [`tagged_images()`](/docs/api-reference/people/tagged-images) — Get paginated tagged images for a person.
+- [`translations()`](/docs/api-reference/people/translations) — Get the translated names and biographies available for a person.
+- [`tv_credits()`](/docs/api-reference/people/tv-credits) — Get TV cast and crew credits for a person.

--- a/apps/docs/content/docs/api-reference/people/latest.mdx
+++ b/apps/docs/content/docs/api-reference/people/latest.mdx
@@ -1,0 +1,21 @@
+---
+title: Latest
+description: Get the most recently added person on TMDB.
+---
+
+```ts
+async latest(): Promise<PersonDetails>
+```
+
+> **TMDB Reference:** [Person Latest ID](https://developer.themoviedb.org/reference/person-latest-id)
+
+## Returns
+
+A [`PersonDetails`](/docs/types/people#persondetails) object for the most recently added person.
+
+## Example
+
+```ts
+const latest = await tmdb.people.latest();
+console.log(latest.id, latest.name);
+```

--- a/apps/docs/content/docs/api-reference/people/movie-credits.mdx
+++ b/apps/docs/content/docs/api-reference/people/movie-credits.mdx
@@ -1,0 +1,33 @@
+---
+title: Movie Credits
+description: Query the movie cast and crew credits for a person.
+---
+
+```ts
+async movie_credits(params: PersonCreditsParams): Promise<PersonMovieCredits>
+```
+
+> **TMDB Reference:** [Person Movie Credits](https://developer.themoviedb.org/reference/person-movie-credits)
+
+## Parameters
+
+| Name        | Type                                                | Required | Description                                          |
+| ----------- | --------------------------------------------------- | -------- | ---------------------------------------------------- |
+| `person_id` | `number`                                            | ✅       | TMDB person identifier.                              |
+| `language`  | [`Language`](/docs/types/options/language#language) | ❌       | Language for localized results. Defaults to `en-US`. |
+
+## Returns
+
+A [`PersonMovieCredits`](/docs/types/people#personmoviecredits) object containing cast and crew credits.
+
+## Example
+
+```ts
+const credits = await tmdb.people.movie_credits({ person_id: 31 });
+console.log(credits.cast.length, credits.crew.length);
+```
+
+## Related Types
+
+- [`PersonMovieCredits`](/docs/types/people#personmoviecredits)
+- [`PersonCreditsParams`](/docs/types/people#personcreditsparams)

--- a/apps/docs/content/docs/api-reference/people/tagged-images.mdx
+++ b/apps/docs/content/docs/api-reference/people/tagged-images.mdx
@@ -1,0 +1,35 @@
+---
+title: Tagged Images
+description: Query the paginated tagged images for a person.
+---
+
+Returns images where the person has been tagged, along with the tagged movie or TV media payload.
+
+```ts
+async tagged_images(params: PersonTaggedImagesParams): Promise<PersonTaggedImages>
+```
+
+> **TMDB Reference:** [Person Tagged Images](https://developer.themoviedb.org/reference/person-tagged-images)
+
+## Parameters
+
+| Name        | Type     | Required | Description                            |
+| ----------- | -------- | -------- | -------------------------------------- |
+| `person_id` | `number` | ✅       | TMDB person identifier.                |
+| `page`      | `number` | ❌       | Page number for paginated image tags.  |
+
+## Returns
+
+A [`PersonTaggedImages`](/docs/types/people#persontaggedimages) object containing paginated tagged images.
+
+## Example
+
+```ts
+const tagged = await tmdb.people.tagged_images({ person_id: 31, page: 1 });
+console.log(tagged.results.length);
+```
+
+## Related Types
+
+- [`PersonTaggedImages`](/docs/types/people#persontaggedimages)
+- [`PersonTaggedImagesParams`](/docs/types/people#persontaggedimagesparams)

--- a/apps/docs/content/docs/api-reference/people/translations.mdx
+++ b/apps/docs/content/docs/api-reference/people/translations.mdx
@@ -1,0 +1,32 @@
+---
+title: Translations
+description: Query the translated names and biographies available for a person.
+---
+
+```ts
+async translations(params: PersonTranslationsParams): Promise<PersonTranslations>
+```
+
+> **TMDB Reference:** [Person Translations](https://developer.themoviedb.org/reference/person-translations)
+
+## Parameters
+
+| Name        | Type     | Required | Description              |
+| ----------- | -------- | -------- | ------------------------ |
+| `person_id` | `number` | ✅       | TMDB person identifier.  |
+
+## Returns
+
+A [`PersonTranslations`](/docs/types/people#persontranslations) object containing all available translations.
+
+## Example
+
+```ts
+const translations = await tmdb.people.translations({ person_id: 31 });
+console.log(translations.translations.length);
+```
+
+## Related Types
+
+- [`PersonTranslations`](/docs/types/people#persontranslations)
+- [`PersonTranslationsParams`](/docs/types/people#persontranslationsparams)

--- a/apps/docs/content/docs/api-reference/people/tv-credits.mdx
+++ b/apps/docs/content/docs/api-reference/people/tv-credits.mdx
@@ -1,0 +1,33 @@
+---
+title: TV Credits
+description: Query the TV cast and crew credits for a person.
+---
+
+```ts
+async tv_credits(params: PersonCreditsParams): Promise<PersonTVCredits>
+```
+
+> **TMDB Reference:** [Person TV Credits](https://developer.themoviedb.org/reference/person-tv-credits)
+
+## Parameters
+
+| Name        | Type                                                | Required | Description                                          |
+| ----------- | --------------------------------------------------- | -------- | ---------------------------------------------------- |
+| `person_id` | `number`                                            | ✅       | TMDB person identifier.                              |
+| `language`  | [`Language`](/docs/types/options/language#language) | ❌       | Language for localized results. Defaults to `en-US`. |
+
+## Returns
+
+A [`PersonTVCredits`](/docs/types/people#persontvcredits) object containing cast and crew credits.
+
+## Example
+
+```ts
+const credits = await tmdb.people.tv_credits({ person_id: 31 });
+console.log(credits.cast.length, credits.crew.length);
+```
+
+## Related Types
+
+- [`PersonTVCredits`](/docs/types/people#persontvcredits)
+- [`PersonCreditsParams`](/docs/types/people#personcreditsparams)

--- a/apps/docs/content/docs/types/index.mdx
+++ b/apps/docs/content/docs/types/index.mdx
@@ -16,6 +16,7 @@ icon: BookType
 - [Keywords](/docs/types/keywords) - Types used in the KeywordsAPI
 - [Movies](/docs/types/movies) - Types used in the MoviesAPI
 - [Networks](/docs/types/networks) - Types used in the NetworksAPI
+- [People](/docs/types/people) - Types used in the PeopleAPI
 - [Search](/docs/types/search) - Types used in the SearchAPI
 - [TV Series](/docs/types/tv-series) - Types used in the TVSeriesAPI
 - [TV Seasons](/docs/types/tv-seasons) - Types used in the TVSeasonsAPI

--- a/apps/docs/content/docs/types/meta.json
+++ b/apps/docs/content/docs/types/meta.json
@@ -11,6 +11,7 @@
 		"companies.mdx",
 		"credits.mdx",
 		"networks.mdx",
+		"people.mdx",
 		"people-lists.mdx",
 		"keywords.mdx",
 		"watch-providers.mdx",

--- a/apps/docs/content/docs/types/people.mdx
+++ b/apps/docs/content/docs/types/people.mdx
@@ -1,0 +1,113 @@
+---
+title: People
+description: Types related to the People namespace.
+---
+
+Types related to the [PeopleAPI](/docs/api-reference/people) namespace.
+
+import { TypeTable } from "fumadocs-ui/components/type-table";
+
+## `PersonDetails`
+
+<AutoTypeTable path="people.ts" name="PersonDetails" />
+
+## `PersonExternalIDs`
+
+<AutoTypeTable path="people.ts" name="PersonExternalIDs" />
+
+## `PersonImages`
+
+<AutoTypeTable path="people.ts" name="PersonImages" />
+
+## `PersonMovieCredits`
+
+<AutoTypeTable path="people.ts" name="PersonMovieCredits" />
+
+## `PersonTVCredits`
+
+<AutoTypeTable path="people.ts" name="PersonTVCredits" />
+
+## `PersonCombinedCredits`
+
+<AutoTypeTable path="people.ts" name="PersonCombinedCredits" />
+
+## `PersonTaggedImages`
+
+<AutoTypeTable path="people.ts" name="PersonTaggedImages" />
+
+## `PersonTranslations`
+
+<AutoTypeTable path="people.ts" name="PersonTranslations" />
+
+## `PersonBaseParam`
+
+<AutoTypeTable path="people.ts" name="PersonBaseParam" />
+
+## `PersonDetailsParams`
+
+<TypeTable
+	type={{
+		person_id: { type: "number", required: true, description: "TMDB person identifier." },
+		append_to_response: {
+			type: "PersonAppendToResponseNamespace | PersonAppendToResponseNamespace[]",
+			description: "Subresources to append to the person details response.",
+		},
+		language: { type: "Language", description: "Language for localized results.", default: "en-US" },
+	}}
+/>
+
+Supported `append_to_response` values:
+`"changes"`, `"combined_credits"`, `"external_ids"`, `"images"`, `"movie_credits"`, `"tagged_images"`, `"translations"`, `"tv_credits"`.
+
+## `PersonChangesParams`
+
+<TypeTable
+	type={{
+		person_id: { type: "number", required: true, description: "TMDB person identifier." },
+		page: { type: "number", description: "Page number for paginated change results." },
+		start_date: { type: "string", description: "Start date in YYYY-MM-DD format." },
+		end_date: { type: "string", description: "End date in YYYY-MM-DD format." },
+	}}
+/>
+
+## `PersonCreditsParams`
+
+<TypeTable
+	type={{
+		person_id: { type: "number", required: true, description: "TMDB person identifier." },
+		language: { type: "Language", description: "Language for localized results.", default: "en-US" },
+	}}
+/>
+
+## `PersonExternalIDsParams`
+
+<TypeTable
+	type={{
+		person_id: { type: "number", required: true, description: "TMDB person identifier." },
+	}}
+/>
+
+## `PersonImagesParams`
+
+<TypeTable
+	type={{
+		person_id: { type: "number", required: true, description: "TMDB person identifier." },
+	}}
+/>
+
+## `PersonTranslationsParams`
+
+<TypeTable
+	type={{
+		person_id: { type: "number", required: true, description: "TMDB person identifier." },
+	}}
+/>
+
+## `PersonTaggedImagesParams`
+
+<TypeTable
+	type={{
+		person_id: { type: "number", required: true, description: "TMDB person identifier." },
+		page: { type: "number", description: "Page number for paginated tagged images." },
+	}}
+/>

--- a/packages/tmdb/src/endpoints/people.ts
+++ b/packages/tmdb/src/endpoints/people.ts
@@ -1,0 +1,162 @@
+import { ENDPOINTS } from "../routes";
+import { TMDBAPIBase } from "./base";
+import type {
+	PersonAppendToResponseNamespace,
+	PersonChanges,
+	PersonChangesParams,
+	PersonCombinedCredits,
+	PersonCreditsParams,
+	PersonDetails,
+	PersonDetailsParams,
+	PersonDetailsWithAppends,
+	PersonExternalIDs,
+	PersonExternalIDsParams,
+	PersonImages,
+	PersonImagesParams,
+	PersonMovieCredits,
+	PersonTaggedImages,
+	PersonTaggedImagesParams,
+	PersonTranslations,
+	PersonTranslationsParams,
+	PersonTVCredits,
+} from "../types/people";
+
+export class PeopleAPI extends TMDBAPIBase {
+	private personPath(person_id: number): string {
+		return `${ENDPOINTS.PEOPLE.DETAILS}/${person_id}`;
+	}
+
+	private personSubPath(person_id: number, route: string): string {
+		return `${this.personPath(person_id)}${route}`;
+	}
+
+	/**
+	 * Details
+	 * GET - https://api.themoviedb.org/3/person/{person_id}
+	 *
+	 * Get the primary person details by TMDB person id.
+	 * @param person_id The TMDB person id.
+	 * @param append_to_response Additional person subresources to append.
+	 * @param language Language for localized results.
+	 * @reference https://developer.themoviedb.org/reference/person-details
+	 */
+	async details<T extends readonly PersonAppendToResponseNamespace[] = []>(
+		params: PersonDetailsParams & { append_to_response?: T[number] | T },
+	): Promise<T extends [] ? PersonDetails : PersonDetailsWithAppends<T>> {
+		const { language = this.defaultOptions.language, person_id, ...rest } = params;
+		return this.client.request(this.personPath(person_id), { language, ...rest });
+	}
+
+	/**
+	 * Changes
+	 * GET - https://api.themoviedb.org/3/person/{person_id}/changes
+	 *
+	 * Get the change history for a person.
+	 * @reference https://developer.themoviedb.org/reference/person-changes
+	 */
+	async changes(params: PersonChangesParams): Promise<PersonChanges> {
+		const { person_id, ...rest } = params;
+		return this.client.request(this.personSubPath(person_id, ENDPOINTS.PEOPLE.CHANGES), rest);
+	}
+
+	/**
+	 * Combined Credits
+	 * GET - https://api.themoviedb.org/3/person/{person_id}/combined_credits
+	 *
+	 * Get movie and TV credits in a single response.
+	 * @reference https://developer.themoviedb.org/reference/person-combined-credits
+	 */
+	async combined_credits(params: PersonCreditsParams): Promise<PersonCombinedCredits> {
+		const { language = this.defaultOptions.language, person_id, ...rest } = params;
+		return this.client.request(this.personSubPath(person_id, ENDPOINTS.PEOPLE.COMBINED_CREDITS), {
+			language,
+			...rest,
+		});
+	}
+
+	/**
+	 * External IDs
+	 * GET - https://api.themoviedb.org/3/person/{person_id}/external_ids
+	 *
+	 * Get external platform identifiers for a person.
+	 * @reference https://developer.themoviedb.org/reference/person-external-ids
+	 */
+	async external_ids(params: PersonExternalIDsParams): Promise<PersonExternalIDs> {
+		return this.client.request(this.personSubPath(params.person_id, ENDPOINTS.PEOPLE.EXTERNAL_IDS));
+	}
+
+	/**
+	 * Images
+	 * GET - https://api.themoviedb.org/3/person/{person_id}/images
+	 *
+	 * Get profile images for a person.
+	 * @reference https://developer.themoviedb.org/reference/person-images
+	 */
+	async images(params: PersonImagesParams): Promise<PersonImages> {
+		return this.client.request(this.personSubPath(params.person_id, ENDPOINTS.PEOPLE.IMAGES));
+	}
+
+	/**
+	 * Latest
+	 * GET - https://api.themoviedb.org/3/person/latest
+	 *
+	 * Get the newest person id added to TMDB.
+	 * @reference https://developer.themoviedb.org/reference/person-latest-id
+	 */
+	async latest(): Promise<PersonDetails> {
+		return this.client.request(`${ENDPOINTS.PEOPLE.DETAILS}${ENDPOINTS.PEOPLE.LATEST}`);
+	}
+
+	/**
+	 * Movie Credits
+	 * GET - https://api.themoviedb.org/3/person/{person_id}/movie_credits
+	 *
+	 * Get a person's movie cast and crew credits.
+	 * @reference https://developer.themoviedb.org/reference/person-movie-credits
+	 */
+	async movie_credits(params: PersonCreditsParams): Promise<PersonMovieCredits> {
+		const { language = this.defaultOptions.language, person_id, ...rest } = params;
+		return this.client.request(this.personSubPath(person_id, ENDPOINTS.PEOPLE.MOVIE_CREDITS), {
+			language,
+			...rest,
+		});
+	}
+
+	/**
+	 * Tagged Images
+	 * GET - https://api.themoviedb.org/3/person/{person_id}/tagged_images
+	 *
+	 * Get images where the person has been tagged.
+	 * @reference https://developer.themoviedb.org/reference/person-tagged-images
+	 */
+	async tagged_images(params: PersonTaggedImagesParams): Promise<PersonTaggedImages> {
+		const { person_id, ...rest } = params;
+		return this.client.request(this.personSubPath(person_id, ENDPOINTS.PEOPLE.TAGGED_IMAGES), rest);
+	}
+
+	/**
+	 * Translations
+	 * GET - https://api.themoviedb.org/3/person/{person_id}/translations
+	 *
+	 * Get the translations available for a person biography and name.
+	 * @reference https://developer.themoviedb.org/reference/person-translations
+	 */
+	async translations(params: PersonTranslationsParams): Promise<PersonTranslations> {
+		return this.client.request(this.personSubPath(params.person_id, ENDPOINTS.PEOPLE.TRANSLATIONS));
+	}
+
+	/**
+	 * TV Credits
+	 * GET - https://api.themoviedb.org/3/person/{person_id}/tv_credits
+	 *
+	 * Get a person's TV cast and crew credits.
+	 * @reference https://developer.themoviedb.org/reference/person-tv-credits
+	 */
+	async tv_credits(params: PersonCreditsParams): Promise<PersonTVCredits> {
+		const { language = this.defaultOptions.language, person_id, ...rest } = params;
+		return this.client.request(this.personSubPath(person_id, ENDPOINTS.PEOPLE.TV_CREDITS), {
+			language,
+			...rest,
+		});
+	}
+}

--- a/packages/tmdb/src/routes.ts
+++ b/packages/tmdb/src/routes.ts
@@ -68,6 +68,18 @@ export const ENDPOINTS = {
 		ALTERNATIVE_NAMES: "/alternative_names",
 		IMAGES: "/images",
 	},
+	PEOPLE: {
+		DETAILS: "/person",
+		CHANGES: "/changes",
+		COMBINED_CREDITS: "/combined_credits",
+		EXTERNAL_IDS: "/external_ids",
+		IMAGES: "/images",
+		LATEST: "/latest",
+		MOVIE_CREDITS: "/movie_credits",
+		TAGGED_IMAGES: "/tagged_images",
+		TRANSLATIONS: "/translations",
+		TV_CREDITS: "/tv_credits",
+	},
 	SEARCH: {
 		MOVIE: "/search/movie",
 		COLLECTION: "/search/collection",

--- a/packages/tmdb/src/tests/people/people.integration.test.ts
+++ b/packages/tmdb/src/tests/people/people.integration.test.ts
@@ -1,0 +1,91 @@
+/// <reference types="node" />
+import { describe, expect, it } from "vitest";
+
+import { TMDB } from "../../tmdb";
+
+const token = process.env.TMDB_BEARER_TOKEN;
+if (!token) throw new Error("TMDB_BEARER_TOKEN is not set, please set it in your environment variables.");
+
+const tmdb = new TMDB(token, { language: "en-US", region: "US" });
+const personId = 31;
+
+describe("PeopleAPI (integration)", () => {
+	it("(DETAILS) should fetch person details", async () => {
+		const person = await tmdb.people.details({ person_id: personId });
+		expect(person.id).toBe(personId);
+		expect(typeof person.name).toBe("string");
+		expect(person.name.length).toBeGreaterThan(0);
+	});
+
+	it("(DETAILS + appends) should include appended subresources", async () => {
+		const person = await tmdb.people.details({
+			person_id: personId,
+			append_to_response: ["images", "external_ids", "movie_credits"],
+		});
+		expect(person.images).toBeDefined();
+		expect(Array.isArray(person.images.profiles)).toBe(true);
+		expect(person.external_ids).toBeDefined();
+		expect(person.movie_credits).toBeDefined();
+		expect(Array.isArray(person.movie_credits.cast)).toBe(true);
+	});
+
+	it("(CHANGES) should fetch person changes", async () => {
+		const changes = await tmdb.people.changes({ person_id: personId });
+		expect(Array.isArray(changes.changes)).toBe(true);
+	});
+
+	it("(COMBINED CREDITS) should fetch movie and tv credits", async () => {
+		const credits = await tmdb.people.combined_credits({ person_id: personId });
+		expect(credits.id).toBe(personId);
+		expect(Array.isArray(credits.cast)).toBe(true);
+		expect(Array.isArray(credits.crew)).toBe(true);
+		expect(credits.cast.length + credits.crew.length).toBeGreaterThan(0);
+	});
+
+	it("(EXTERNAL IDS) should fetch person external ids", async () => {
+		const ids = await tmdb.people.external_ids({ person_id: personId });
+		expect(ids.id).toBe(personId);
+		expect(typeof ids.imdb_id === "string" || ids.imdb_id === undefined).toBe(true);
+	});
+
+	it("(IMAGES) should fetch person profile images", async () => {
+		const images = await tmdb.people.images({ person_id: personId });
+		expect(images.id).toBe(personId);
+		expect(Array.isArray(images.profiles)).toBe(true);
+	});
+
+	it("(LATEST) should fetch the latest person record", async () => {
+		const latest = await tmdb.people.latest();
+		expect(typeof latest.id).toBe("number");
+		expect(typeof latest.name).toBe("string");
+	});
+
+	it("(MOVIE CREDITS) should fetch movie credits", async () => {
+		const credits = await tmdb.people.movie_credits({ person_id: personId });
+		expect(credits.id).toBe(personId);
+		expect(Array.isArray(credits.cast)).toBe(true);
+		expect(Array.isArray(credits.crew)).toBe(true);
+	});
+
+	it("(TAGGED IMAGES) should fetch tagged images", async () => {
+		const taggedImages = await tmdb.people.tagged_images({ person_id: personId });
+		expect(taggedImages.id).toBe(personId);
+		expect(typeof taggedImages.page).toBe("number");
+		expect(taggedImages.page).toBeGreaterThanOrEqual(0);
+		expect(Array.isArray(taggedImages.results)).toBe(true);
+	});
+
+	it("(TRANSLATIONS) should fetch person translations", async () => {
+		const translations = await tmdb.people.translations({ person_id: personId });
+		expect(translations.id).toBe(personId);
+		expect(Array.isArray(translations.translations)).toBe(true);
+		expect(translations.translations.length).toBeGreaterThan(0);
+	});
+
+	it("(TV CREDITS) should fetch tv credits", async () => {
+		const credits = await tmdb.people.tv_credits({ person_id: personId });
+		expect(credits.id).toBe(personId);
+		expect(Array.isArray(credits.cast)).toBe(true);
+		expect(Array.isArray(credits.crew)).toBe(true);
+	});
+});

--- a/packages/tmdb/src/tests/people/people.test.ts
+++ b/packages/tmdb/src/tests/people/people.test.ts
@@ -1,0 +1,131 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ApiClient } from "../../client";
+import { PeopleAPI } from "../../endpoints/people";
+
+describe("PeopleAPI", () => {
+	let clientMock: ApiClient;
+	let peopleAPI: PeopleAPI;
+
+	beforeEach(() => {
+		clientMock = new ApiClient("valid_access_token");
+		clientMock.request = vi.fn();
+		peopleAPI = new PeopleAPI(clientMock);
+	});
+
+	describe("details", () => {
+		it("should call client.request with correct endpoint and language", async () => {
+			await peopleAPI.details({ person_id: 31, language: "en-US" });
+			expect(clientMock.request).toHaveBeenCalledOnce();
+			expect(clientMock.request).toHaveBeenCalledWith("/person/31", { language: "en-US" });
+		});
+
+		it("should pass append_to_response when specified", async () => {
+			await peopleAPI.details({ person_id: 31, append_to_response: ["images", "external_ids"] });
+			expect(clientMock.request).toHaveBeenCalledWith("/person/31", {
+				language: undefined,
+				append_to_response: ["images", "external_ids"],
+			});
+		});
+
+		it("should use defaultOptions.language when not provided", async () => {
+			peopleAPI = new PeopleAPI(clientMock, { language: "it-IT" });
+			await peopleAPI.details({ person_id: 31 });
+			expect(clientMock.request).toHaveBeenCalledWith("/person/31", expect.objectContaining({ language: "it-IT" }));
+		});
+	});
+
+	describe("changes", () => {
+		it("should call client.request with the correct endpoint and params", async () => {
+			await peopleAPI.changes({ person_id: 31, page: 2, start_date: "2024-01-01", end_date: "2024-01-14" });
+			expect(clientMock.request).toHaveBeenCalledOnce();
+			expect(clientMock.request).toHaveBeenCalledWith("/person/31/changes", {
+				page: 2,
+				start_date: "2024-01-01",
+				end_date: "2024-01-14",
+			});
+		});
+	});
+
+	describe("combined_credits", () => {
+		it("should call client.request with the correct endpoint and language", async () => {
+			await peopleAPI.combined_credits({ person_id: 31, language: "en-US" });
+			expect(clientMock.request).toHaveBeenCalledOnce();
+			expect(clientMock.request).toHaveBeenCalledWith("/person/31/combined_credits", { language: "en-US" });
+		});
+
+		it("should use defaultOptions.language when not provided", async () => {
+			peopleAPI = new PeopleAPI(clientMock, { language: "fr-FR" });
+			await peopleAPI.combined_credits({ person_id: 31 });
+			expect(clientMock.request).toHaveBeenCalledWith("/person/31/combined_credits", { language: "fr-FR" });
+		});
+	});
+
+	describe("external_ids", () => {
+		it("should call client.request with the correct endpoint", async () => {
+			await peopleAPI.external_ids({ person_id: 31 });
+			expect(clientMock.request).toHaveBeenCalledOnce();
+			expect(clientMock.request).toHaveBeenCalledWith("/person/31/external_ids");
+		});
+	});
+
+	describe("images", () => {
+		it("should call client.request with the correct endpoint", async () => {
+			await peopleAPI.images({ person_id: 31 });
+			expect(clientMock.request).toHaveBeenCalledOnce();
+			expect(clientMock.request).toHaveBeenCalledWith("/person/31/images");
+		});
+	});
+
+	describe("latest", () => {
+		it("should call client.request with the correct endpoint", async () => {
+			await peopleAPI.latest();
+			expect(clientMock.request).toHaveBeenCalledOnce();
+			expect(clientMock.request).toHaveBeenCalledWith("/person/latest");
+		});
+	});
+
+	describe("movie_credits", () => {
+		it("should call client.request with the correct endpoint and language", async () => {
+			await peopleAPI.movie_credits({ person_id: 31, language: "en-US" });
+			expect(clientMock.request).toHaveBeenCalledOnce();
+			expect(clientMock.request).toHaveBeenCalledWith("/person/31/movie_credits", { language: "en-US" });
+		});
+
+		it("should use defaultOptions.language when not provided", async () => {
+			peopleAPI = new PeopleAPI(clientMock, { language: "es-ES" });
+			await peopleAPI.movie_credits({ person_id: 31 });
+			expect(clientMock.request).toHaveBeenCalledWith("/person/31/movie_credits", { language: "es-ES" });
+		});
+	});
+
+	describe("tagged_images", () => {
+		it("should call client.request with the correct endpoint and params", async () => {
+			await peopleAPI.tagged_images({ person_id: 31, page: 2 });
+			expect(clientMock.request).toHaveBeenCalledOnce();
+			expect(clientMock.request).toHaveBeenCalledWith("/person/31/tagged_images", { page: 2 });
+		});
+	});
+
+	describe("translations", () => {
+		it("should call client.request with the correct endpoint", async () => {
+			await peopleAPI.translations({ person_id: 31 });
+			expect(clientMock.request).toHaveBeenCalledOnce();
+			expect(clientMock.request).toHaveBeenCalledWith("/person/31/translations");
+		});
+	});
+
+	describe("tv_credits", () => {
+		it("should call client.request with the correct endpoint and language", async () => {
+			await peopleAPI.tv_credits({ person_id: 31, language: "en-US" });
+			expect(clientMock.request).toHaveBeenCalledOnce();
+			expect(clientMock.request).toHaveBeenCalledWith("/person/31/tv_credits", { language: "en-US" });
+		});
+
+		it("should use defaultOptions.language when not provided", async () => {
+			peopleAPI = new PeopleAPI(clientMock, { language: "de-DE" });
+			await peopleAPI.tv_credits({ person_id: 31 });
+			expect(clientMock.request).toHaveBeenCalledWith("/person/31/tv_credits", { language: "de-DE" });
+		});
+	});
+});

--- a/packages/tmdb/src/tests/tmdb.test.ts
+++ b/packages/tmdb/src/tests/tmdb.test.ts
@@ -38,4 +38,9 @@ describe("TMDB API Client", () => {
 		const tmdb = new TMDB("valid_access_token");
 		expect(tmdb.networks).toBeDefined();
 	});
+
+	it("should expose the people api", () => {
+		const tmdb = new TMDB("valid_access_token");
+		expect(tmdb.people).toBeDefined();
+	});
 });

--- a/packages/tmdb/src/tmdb.ts
+++ b/packages/tmdb/src/tmdb.ts
@@ -27,6 +27,7 @@ import { TVSeasonsAPI } from "./endpoints/tv_seasons";
 import { TrendingAPI } from "./endpoints/trending";
 import { ReviewsAPI } from "./endpoints/reviews";
 import { PeopleListsAPI } from "./endpoints/people_lists";
+import { PeopleAPI } from "./endpoints/people";
 
 export class TMDB {
 	private client: ApiClient;
@@ -55,6 +56,7 @@ export class TMDB {
 	public trending: TrendingAPI;
 	public reviews: ReviewsAPI;
 	public people_lists: PeopleListsAPI;
+	public people: PeopleAPI;
 	// etc...
 
 	/**
@@ -90,5 +92,6 @@ export class TMDB {
 		this.trending = new TrendingAPI(this.client, this.options);
 		this.reviews = new ReviewsAPI(this.client, this.options);
 		this.people_lists = new PeopleListsAPI(this.client, this.options);
+		this.people = new PeopleAPI(this.client, this.options);
 	}
 }

--- a/packages/tmdb/src/types/index.ts
+++ b/packages/tmdb/src/types/index.ts
@@ -18,3 +18,4 @@ export * from "./keywords";
 export * from "./credits";
 export * from "./reviews";
 export * from "./people-lists";
+export * from "./people";

--- a/packages/tmdb/src/types/people.ts
+++ b/packages/tmdb/src/types/people.ts
@@ -1,0 +1,254 @@
+import {
+	Changes,
+	DateRange,
+	ImageItem,
+	ImagesResult,
+	MediaType,
+	PaginatedResponse,
+	TranslationResults,
+	WithLanguage,
+	WithPage,
+} from "./common";
+import { MovieResultItem, TVSeriesResultItem } from "./search";
+import { Prettify } from "./utility";
+
+/**
+ * Top-level person details returned by TMDB.
+ */
+export type PersonDetails = {
+	/** Whether the person is marked as adult content */
+	adult: boolean;
+	/** Alternative names or aliases */
+	also_known_as: string[];
+	/** Localized or default biography text */
+	biography?: string;
+	/** Date of birth in ISO 8601 format */
+	birthday?: string;
+	/** Date of death in ISO 8601 format, if applicable */
+	deathday?: string;
+	/** Gender code reported by TMDB */
+	gender: number;
+	/** Official homepage URL, if available */
+	homepage?: string;
+	/** TMDB person identifier */
+	id: number;
+	/** IMDb identifier, if linked */
+	imdb_id?: string;
+	/** Primary department the person is known for */
+	known_for_department?: string;
+	/** Display name */
+	name: string;
+	/** Place of birth, if known */
+	place_of_birth?: string;
+	/** Popularity score */
+	popularity: number;
+	/** Relative path to the profile image */
+	profile_path?: string;
+};
+
+/**
+ * Endpoints that can be appended to a person details request.
+ */
+export type PersonAppendToResponseNamespace =
+	| "changes"
+	| "combined_credits"
+	| "external_ids"
+	| "images"
+	| "movie_credits"
+	| "tagged_images"
+	| "translations"
+	| "tv_credits";
+
+/**
+ * Person details with appended subresources.
+ */
+export type PersonDetailsWithAppends<T extends readonly PersonAppendToResponseNamespace[]> = PersonDetails & {
+	[K in T[number]]: PersonAppendableMap[K];
+};
+
+/**
+ * Changes made to a person resource.
+ */
+export type PersonChanges = Changes;
+
+/**
+ * External identifiers linked to a person.
+ */
+export type PersonExternalIDs = {
+	id: number;
+	freebase_mid?: string;
+	freebase_id?: string;
+	imdb_id?: string;
+	tvrage_id?: number;
+	wikidata_id?: string;
+	facebook_id?: string;
+	instagram_id?: string;
+	tiktok_id?: string;
+	twitter_id?: string;
+	youtube_id?: string;
+};
+
+/**
+ * Profile images belonging to a person.
+ */
+export type PersonImages = ImagesResult<ImageItem, "profiles">;
+
+/**
+ * Cast credit for a movie on a person profile.
+ */
+export type PersonMovieCastCredit = MovieResultItem & {
+	character: string;
+	credit_id: string;
+	order: number;
+};
+
+/**
+ * Crew credit for a movie on a person profile.
+ */
+export type PersonMovieCrewCredit = MovieResultItem & {
+	credit_id: string;
+	department: string;
+	job: string;
+};
+
+/**
+ * Movie credits for a person.
+ */
+export type PersonMovieCredits = {
+	id: number;
+	cast: PersonMovieCastCredit[];
+	crew: PersonMovieCrewCredit[];
+};
+
+/**
+ * Cast credit for a TV show on a person profile.
+ */
+export type PersonTVCastCredit = TVSeriesResultItem & {
+	character: string;
+	credit_id: string;
+	episode_count: number;
+};
+
+/**
+ * Crew credit for a TV show on a person profile.
+ */
+export type PersonTVCrewCredit = TVSeriesResultItem & {
+	credit_id: string;
+	department: string;
+	episode_count: number;
+	job: string;
+};
+
+/**
+ * TV credits for a person.
+ */
+export type PersonTVCredits = {
+	id: number;
+	cast: PersonTVCastCredit[];
+	crew: PersonTVCrewCredit[];
+};
+
+/**
+ * Combined movie/TV cast credit for a person.
+ */
+export type PersonCombinedCastCredit =
+	| (PersonMovieCastCredit & { media_type: "movie" })
+	| (PersonTVCastCredit & { media_type: "tv" });
+
+/**
+ * Combined movie/TV crew credit for a person.
+ */
+export type PersonCombinedCrewCredit =
+	| (PersonMovieCrewCredit & { media_type: "movie" })
+	| (PersonTVCrewCredit & { media_type: "tv" });
+
+/**
+ * Combined credits for a person.
+ */
+export type PersonCombinedCredits = {
+	id: number;
+	cast: PersonCombinedCastCredit[];
+	crew: PersonCombinedCrewCredit[];
+};
+
+/**
+ * Tagged image media payload associated with a person image tag.
+ */
+export type PersonTaggedImageMedia =
+	| (MovieResultItem & { media_type: "movie" })
+	| (TVSeriesResultItem & { media_type: "tv" });
+
+/**
+ * A single tagged image entry for a person.
+ */
+export type PersonTaggedImage = ImageItem & {
+	id: string;
+	image_type: string;
+	media: PersonTaggedImageMedia;
+	media_type: MediaType;
+};
+
+/**
+ * Paginated tagged images for a person.
+ */
+export type PersonTaggedImages = PaginatedResponse<PersonTaggedImage> & {
+	id: number;
+};
+
+/**
+ * Translation payload for person records.
+ */
+export type PersonTranslationData = {
+	biography?: string;
+	name?: string;
+};
+
+/**
+ * Available translations for a person.
+ */
+export type PersonTranslations = TranslationResults<PersonTranslationData>;
+
+/**
+ * Mapping of person append keys to their response types.
+ */
+export type PersonAppendableMap = {
+	changes: PersonChanges;
+	combined_credits: PersonCombinedCredits;
+	external_ids: PersonExternalIDs;
+	images: PersonImages;
+	movie_credits: PersonMovieCredits;
+	tagged_images: PersonTaggedImages;
+	translations: PersonTranslations;
+	tv_credits: PersonTVCredits;
+};
+
+/**
+ * Base param for person-specific endpoints.
+ */
+export type PersonBaseParam = {
+	person_id: number;
+};
+
+/**
+ * Parameters for fetching person details.
+ */
+export type PersonDetailsParams = Prettify<
+	PersonBaseParam & {
+		append_to_response?: PersonAppendToResponseNamespace | PersonAppendToResponseNamespace[];
+	} & WithLanguage
+>;
+
+/**
+ * Parameters for fetching person changes.
+ */
+export type PersonChangesParams = Prettify<PersonBaseParam & WithPage & DateRange>;
+
+/**
+ * Parameters for language-aware person credit endpoints.
+ */
+export type PersonCreditsParams = Prettify<PersonBaseParam & WithLanguage>;
+
+export type PersonExternalIDsParams = PersonBaseParam;
+export type PersonImagesParams = PersonBaseParam;
+export type PersonTranslationsParams = PersonBaseParam;
+export type PersonTaggedImagesParams = Prettify<PersonBaseParam & WithPage>;


### PR DESCRIPTION
Add first-class People API support to the SDK.

I needed the `People` API for my own usage, and since `People` is still listed as missing in the README, I put together a solution that tries to follow the current SDK patterns as closely as possible.

This adds a dedicated `tmdb.people` namespace for the person-specific endpoints, while keeping the existing `people_lists.popular()` and `changes.people_list()` structure intact. It also adds typed models, unit and integration coverage, and docs for the new People namespace.

I used TMDB's official OpenAPI spec as the source for the endpoint surface and request/response contracts:
https://developer.themoviedb.org/openapi/tmdb-api.json

I have not previously coordinated with you on taking this area on, so please treat this as a proposed direction rather than me assuming ownership of it. If you’d prefer a different API shape, naming, or docs structure, I’m very happy to make changes.