### PR TITLE
refactor(client): centralize request param serialization

### DIFF
--- a/packages/tmdb/src/client.ts
+++ b/packages/tmdb/src/client.ts
@@ -29,11 +29,21 @@ export class ApiClient {
 	 * `{ language, page }` and `{ page, language }` produce the same key.
 	 */
 	private buildRequestKey(endpoint: string, params: Record<string, unknown>): string {
-		const definedEntries = Object.entries(params)
-			.filter(([, v]) => v !== undefined)
+		const definedEntries = this.serializeParams(params)
 			.sort(([a], [b]) => a.localeCompare(b))
-			.map(([k, v]) => `${k}=${String(v)}`);
+			.map(([key, value]) => `${key}=${value}`);
 		return definedEntries.length > 0 ? `${endpoint}?${definedEntries.join("&")}` : endpoint;
+	}
+
+	/**
+	 * Serializes request params once so URL construction and deduplication keys stay aligned.
+	 * `undefined` values are intentionally skipped because they are not sent to TMDB.
+	 */
+	private serializeParams(params: Record<string, unknown | undefined>): Array<[string, string]> {
+		return Object.entries(params).flatMap(([key, value]) => {
+			if (value === undefined) return [];
+			return [[key, String(value)]];
+		});
 	}
 
 	/**
@@ -70,9 +80,8 @@ export class ApiClient {
 		const url = new URL(`${this.baseUrl}${endpoint}`);
 		const jwt = isJwt(this.accessToken);
 
-		for (const [key, value] of Object.entries(params)) {
-			if (value === undefined) continue;
-			url.searchParams.append(key, String(value));
+		for (const [key, value] of this.serializeParams(params)) {
+			url.searchParams.append(key, value);
 		}
 
 		if (!jwt) {

--- a/packages/tmdb/src/tests/client/client.deduplication.test.ts
+++ b/packages/tmdb/src/tests/client/client.deduplication.test.ts
@@ -147,6 +147,38 @@ describe("ApiClient deduplication", () => {
 		expect(r2).toEqual({ id: 550 });
 	});
 
+	it("treats array-valued params with different key order as the same request", async () => {
+		const client = new ApiClient(token);
+
+		let resolveJson!: (value: unknown) => void;
+		const jsonPromise = new Promise((resolve) => {
+			resolveJson = resolve;
+		});
+
+		const response: MockResponse = {
+			ok: true,
+			status: 200,
+			statusText: "OK",
+			url: "https://api.themoviedb.org/3/movie/550/images",
+			headers: makeHeaders({}),
+			json: () => jsonPromise,
+		};
+
+		(globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue(response);
+
+		const [r1, r2] = await Promise.all([
+			client.request("/movie/550/images", { language: "en-US", include_image_language: ["en", "null"] }),
+			client.request("/movie/550/images", { include_image_language: ["en", "null"], language: "en-US" }),
+			(async () => {
+				resolveJson({ id: 550 });
+			})(),
+		]).then(([a, b]) => [a, b]);
+
+		expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+		expect(r1).toEqual({ id: 550 });
+		expect(r2).toEqual({ id: 550 });
+	});
+
 	it("allows a second request after the first one completes", async () => {
 		const client = new ApiClient(token);
 

--- a/packages/tmdb/src/tests/client/client.logger.test.ts
+++ b/packages/tmdb/src/tests/client/client.logger.test.ts
@@ -190,6 +190,30 @@ describe("ApiClient logger", () => {
 		expect(calledUrl).not.toContain("skipped");
 	});
 
+	it("should serialize array param values consistently in the URL", async () => {
+		const client = new ApiClient(token);
+
+		const response: MockResponse = {
+			ok: true,
+			status: 200,
+			statusText: "OK",
+			url: "https://api.themoviedb.org/3/test",
+			headers: makeHeaders({}),
+			json: async () => ({}),
+		};
+
+		(globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue(response);
+
+		await client.request("/test", {
+			language: "en-US",
+			include_image_language: ["en", "null"],
+		});
+
+		const calledUrl = new URL((globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0][0] as string);
+		expect(calledUrl.searchParams.get("language")).toBe("en-US");
+		expect(calledUrl.searchParams.get("include_image_language")).toBe("en,null");
+	});
+
 	it("should fall back to statusText when error body is a non-object JSON value", async () => {
 		const client = new ApiClient(token);
 


### PR DESCRIPTION
Centralize request param serialization inside `ApiClient` so request deduplication and URL query construction use the same logic.

Before this change, the client built deduplication keys and request URLs through separate serialization paths. They behaved the same for the current cases, but keeping them split made the request flow easier to drift over time and harder to reason about when adding new params.

This refactor introduces a shared serializer that is used for both the in-flight request key and the final URL. That keeps the request shape consistent in one place and makes the behavior around skipped `undefined` values explicit.

I also added regression coverage for array-valued params to make sure:
- param order does not break deduplication
- query serialization stays aligned with the deduplication key path

Validated locally with the SDK checks: typecheck, lint, full test run, and coverage.
