### PR TITLE
test(sdk): close remaining coverage gaps

### DIFF
--- a/packages/tmdb/src/endpoints/collections.ts
+++ b/packages/tmdb/src/endpoints/collections.ts
@@ -44,7 +44,7 @@ export class CollectionsAPI extends TMDBAPIBase {
 	 */
 	async images(params: CollectionImagesParams): Promise<CollectionImages> {
 		const endpoint = `${this.collectionPath(params.collection_id)}${ENDPOINTS.COLLECTIONS.IMAGES}`;
-		const requestParams = this.withLanguage(params) ?? params;
+		const requestParams = this.withLanguage(params);
 		return this.client.request<CollectionImages>(endpoint, requestParams);
 	}
 

--- a/packages/tmdb/src/endpoints/companies.ts
+++ b/packages/tmdb/src/endpoints/companies.ts
@@ -55,7 +55,7 @@ export class CompaniesAPI extends TMDBAPIBase {
 	 */
 	async images(params: CompanyImagesParams): Promise<CompanyImages> {
 		const endpoint = `${this.companyPath(params.company_id)}${ENDPOINTS.COMPANIES.IMAGES}`;
-		const requestParams = this.withLanguage(params) ?? params;
+		const requestParams = this.withLanguage(params);
 		return this.client.request<CompanyImages>(endpoint, requestParams);
 	}
 }

--- a/packages/tmdb/src/endpoints/credits.ts
+++ b/packages/tmdb/src/endpoints/credits.ts
@@ -19,7 +19,7 @@ export class CreditsAPI extends TMDBAPIBase {
 	 */
 	async details(params: CreditDetailsParams): Promise<CreditDetails> {
 		const endpoint = this.creditPath(params.credit_id);
-		const requestParams = this.withLanguage(params) ?? params;
+		const requestParams = this.withLanguage(params);
 		return this.client.request<CreditDetails>(endpoint, requestParams);
 	}
 }

--- a/packages/tmdb/src/endpoints/people_lists.ts
+++ b/packages/tmdb/src/endpoints/people_lists.ts
@@ -15,9 +15,6 @@ export class PeopleListsAPI extends TMDBAPIBase {
 	 * @reference https://developer.themoviedb.org/reference/person-popular-list
 	 */
 	async popular(params: PeopleListParams = {}): Promise<PaginatedResponse<PersonResultItem>> {
-		return this.client.request<PaginatedResponse<PersonResultItem>>(
-			ENDPOINTS.PEOPLE_LISTS.POPULAR,
-			this.withLanguage(params) ?? params,
-		);
+		return this.client.request<PaginatedResponse<PersonResultItem>>(ENDPOINTS.PEOPLE_LISTS.POPULAR, this.withLanguage(params));
 	}
 }

--- a/packages/tmdb/src/tests/discover/discover.test.ts
+++ b/packages/tmdb/src/tests/discover/discover.test.ts
@@ -47,6 +47,11 @@ describe("DiscoverAPI", () => {
 		});
 	});
 
+	it("should return undefined from withMovieDefaults when no params or defaults exist", () => {
+		discoverAPI = new DiscoverAPI(clientMock);
+		expect((discoverAPI as unknown as { withMovieDefaults: (params?: unknown) => unknown }).withMovieDefaults(undefined)).toBeUndefined();
+	});
+
 	it("should keep movie defaults when language and region are explicitly undefined", async () => {
 		await discoverAPI.movie({
 			language: undefined,
@@ -90,6 +95,11 @@ describe("DiscoverAPI", () => {
 			language: "en-US",
 			timezone: "Europe/Rome",
 		});
+	});
+
+	it("should return undefined from withTVDefaults when no params or defaults exist", () => {
+		discoverAPI = new DiscoverAPI(clientMock);
+		expect((discoverAPI as unknown as { withTVDefaults: (params?: unknown) => unknown }).withTVDefaults(undefined)).toBeUndefined();
 	});
 
 	it("should keep tv defaults when language and timezone are explicitly undefined", async () => {

--- a/packages/tmdb/src/tests/errors/tmdb.test.ts
+++ b/packages/tmdb/src/tests/errors/tmdb.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+
+import { TMDBError } from "../../errors/tmdb";
+
+describe("TMDBError", () => {
+	it("defaults tmdb_status_code to -1 when it is omitted", () => {
+		const error = new TMDBError("Boom", 500);
+
+		expect(error.name).toBe("TMDBError");
+		expect(error.message).toBe("Boom");
+		expect(error.http_status_code).toBe(500);
+		expect(error.tmdb_status_code).toBe(-1);
+	});
+
+	it("preserves a provided tmdb_status_code", () => {
+		const error = new TMDBError("Not found", 404, 34);
+
+		expect(error.tmdb_status_code).toBe(34);
+		expect(error.http_status_code).toBe(404);
+	});
+});

--- a/packages/tmdb/src/tests/utils/index.test.ts
+++ b/packages/tmdb/src/tests/utils/index.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from "vitest";
+
+import * as utils from "../../utils";
+
+describe("utils barrel exports", () => {
+	it("re-exports jwt and logger utilities", () => {
+		expect(typeof utils.isJwt).toBe("function");
+		expect(typeof utils.TMDBLogger).toBe("function");
+	});
+});

--- a/packages/tmdb/src/tests/utils/jwt.test.ts
+++ b/packages/tmdb/src/tests/utils/jwt.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+
+import { isJwt } from "../../utils/jwt";
+
+function toBase64Url(value: string): string {
+	const bytes = new TextEncoder().encode(value);
+	let binary = "";
+
+	for (const byte of bytes) {
+		binary += String.fromCharCode(byte);
+	}
+
+	return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+function createToken(header: unknown, payload: unknown, signature = "signature"): string {
+	return [toBase64Url(JSON.stringify(header)), toBase64Url(JSON.stringify(payload)), signature].join(".");
+}
+
+describe("isJwt", () => {
+	it("returns false for non-string values", () => {
+		expect(isJwt(123 as unknown as string)).toBe(false);
+	});
+
+	it("returns false when the token does not have exactly three parts", () => {
+		expect(isJwt("not-a-jwt")).toBe(false);
+		expect(isJwt("one.two")).toBe(false);
+		expect(isJwt("one.two.three.four")).toBe(false);
+	});
+
+	it("returns false when any token part contains invalid base64url characters", () => {
+		expect(isJwt("abc.def.ghi+")).toBe(false);
+	});
+
+	it("returns false when base64url decoding fails", () => {
+		expect(isJwt("a.eyJhbGciOiJIUzI1NiJ9.signature")).toBe(false);
+	});
+
+	it("returns false when decoded json cannot be parsed", () => {
+		const invalidJson = toBase64Url("not json");
+		const validPayload = toBase64Url(JSON.stringify({ sub: "test" }));
+		expect(isJwt(`${invalidJson}.${validPayload}.signature`)).toBe(false);
+	});
+
+	it("returns false when the decoded header is not an object", () => {
+		const header = toBase64Url(JSON.stringify("header"));
+		const payload = toBase64Url(JSON.stringify({ sub: "test" }));
+		expect(isJwt(`${header}.${payload}.signature`)).toBe(false);
+	});
+
+	it("returns false when the decoded header does not include a string alg", () => {
+		expect(isJwt(createToken({}, { sub: "test" }))).toBe(false);
+		expect(isJwt(createToken({ alg: 123 }, { sub: "test" }))).toBe(false);
+	});
+
+	it("returns false when the decoded payload is not an object", () => {
+		const header = toBase64Url(JSON.stringify({ alg: "HS256" }));
+		const payload = toBase64Url(JSON.stringify("payload"));
+		expect(isJwt(`${header}.${payload}.signature`)).toBe(false);
+	});
+
+	it("returns false when exp is present but not a number", () => {
+		expect(isJwt(createToken({ alg: "HS256" }, { exp: "123" }))).toBe(false);
+	});
+
+	it("returns false when nbf is present but not a number", () => {
+		expect(isJwt(createToken({ alg: "HS256" }, { nbf: "123" }))).toBe(false);
+	});
+
+	it("returns false when iat is present but not a number", () => {
+		expect(isJwt(createToken({ alg: "HS256" }, { iat: "123" }))).toBe(false);
+	});
+
+	it("returns false when the payload cannot be base64url decoded", () => {
+		const header = toBase64Url(JSON.stringify({ alg: "HS256" }));
+		expect(isJwt(`${header}.a.signature`)).toBe(false);
+	});
+
+	it("returns true for a well-formed JWT", () => {
+		expect(isJwt(createToken({ alg: "HS256", typ: "JWT" }, { sub: "test", iat: 1, exp: 2 }))).toBe(true);
+	});
+});

--- a/packages/tmdb/src/tests/watch_providers/watch_providers.test.ts
+++ b/packages/tmdb/src/tests/watch_providers/watch_providers.test.ts
@@ -31,6 +31,14 @@ describe("WatchProvidersAPI", () => {
 		});
 	});
 
+	it("should pass undefined params to movie providers when no language defaults exist", async () => {
+		watchProvidersAPI = new WatchProvidersAPI(clientMock);
+		await watchProvidersAPI.movie_providers();
+
+		expect(clientMock.request).toHaveBeenCalledOnce();
+		expect(clientMock.request).toHaveBeenCalledWith("/watch/providers/movie", undefined);
+	});
+
 	it("should call client.request with the correct tv providers parameters", async () => {
 		await watchProvidersAPI.tv_providers({ language: "it-IT" });
 
@@ -40,6 +48,14 @@ describe("WatchProvidersAPI", () => {
 		});
 	});
 
+	it("should pass undefined params to tv providers when no language defaults exist", async () => {
+		watchProvidersAPI = new WatchProvidersAPI(clientMock);
+		await watchProvidersAPI.tv_providers();
+
+		expect(clientMock.request).toHaveBeenCalledOnce();
+		expect(clientMock.request).toHaveBeenCalledWith("/watch/providers/tv", undefined);
+	});
+
 	it("should call client.request with the correct available regions parameters", async () => {
 		await watchProvidersAPI.available_regions({ language: "it-IT" });
 
@@ -47,6 +63,14 @@ describe("WatchProvidersAPI", () => {
 		expect(clientMock.request).toHaveBeenCalledWith("/watch/providers/regions", {
 			language: "it-IT",
 		});
+	});
+
+	it("should pass undefined params to available regions when no language defaults exist", async () => {
+		watchProvidersAPI = new WatchProvidersAPI(clientMock);
+		await watchProvidersAPI.available_regions();
+
+		expect(clientMock.request).toHaveBeenCalledOnce();
+		expect(clientMock.request).toHaveBeenCalledWith("/watch/providers/regions", undefined);
 	});
 
 	it("should return the result from client.request", async () => {


### PR DESCRIPTION
This rounds out the remaining SDK coverage gaps and brings the package coverage report up to 100%.

Most of the changes here are focused tests around a few small areas that were still missing direct coverage, especially JWT validation, `TMDBError`, discover helper branches, watch provider fallback behavior, and the utils barrel exports.

While going through those gaps, I also found a few endpoint methods with redundant `?? params` fallbacks around `withLanguage(...)`. Those branches weren’t doing any real work on the current code paths, so I removed them to keep the implementation a little simpler and to avoid carrying around coverage-only dead branches.

Validated locally with:

- `pnpm --filter @lorenzopant/tmdb test:coverage`

That run now passes with 100% coverage for statements, branches, functions, and lines in the SDK package.
