### PR TITLE
feat: pagination helpers

### DIFF
--- a/apps/docs/content/docs/getting-started/meta.json
+++ b/apps/docs/content/docs/getting-started/meta.json
@@ -1,3 +1,3 @@
 {
-	"pages": ["index", "authentication", "features", "options", "ssr"]
+	"pages": ["index", "authentication", "features", "pagination", "options", "ssr"]
 }

--- a/apps/docs/content/docs/getting-started/pagination.mdx
+++ b/apps/docs/content/docs/getting-started/pagination.mdx
@@ -145,8 +145,8 @@ const movies = await fetchAllPages((p) => tmdb.movie_lists.now_playing({ page: p
 });
 ```
 
-When two items share the same key, the **last occurrence wins** — preserving the most recently
-fetched position, which is typically the more accurate one.
+When two items share the same key, the **last occurrence wins** — the value is replaced with the
+most recently fetched one, but the item retains its original position in the result list.
 
 ---
 

--- a/apps/docs/content/docs/getting-started/pagination.mdx
+++ b/apps/docs/content/docs/getting-started/pagination.mdx
@@ -1,0 +1,245 @@
+---
+title: Pagination
+description: Helpers for working with paginated TMDB responses — lazy iteration, batch collection, and UI metadata.
+icon: ListOrdered
+---
+
+Every TMDB endpoint that returns lists uses offset pagination via a `page` parameter. The response
+always has the shape:
+
+```ts
+type PaginatedResponse<T> = {
+	page: number;
+	total_pages: number;
+	total_results: number;
+	results: T[];
+};
+```
+
+`@lorenzopant/tmdb` ships four standalone utilities that remove the boilerplate of working with
+paginated results. They are generic and work with every paginated method in the client.
+
+```ts
+import {
+	paginate,
+	fetchAllPages,
+	hasNextPage,
+	hasPreviousPage,
+	getPageInfo,
+} from "@lorenzopant/tmdb";
+```
+
+---
+
+## `paginate()`
+
+An async generator that lazily fetches one page at a time. The caller controls when to stop —
+ideal when you need to process or filter results without loading everything into memory first.
+
+```ts
+async function* paginate<T>(
+	fetcher: (page: number) => Promise<PaginatedResponse<T>>,
+	startPage?: number,
+): AsyncGenerator<PaginatedResponse<T>>
+```
+
+### Basic usage
+
+```ts
+for await (const page of paginate((p) => tmdb.search.movies({ query: "batman", page: p }))) {
+	console.log(`Page ${page.page} of ${page.total_pages}`);
+	console.log(page.results);
+}
+```
+
+### Early exit — stop as soon as you find what you need
+
+```ts
+for await (const page of paginate((p) => tmdb.search.movies({ query: "batman", page: p }))) {
+	const hit = page.results.find((m) => m.vote_average > 8.0);
+	if (hit) {
+		console.log(hit);
+		break; // stops fetching immediately — no wasted requests
+	}
+}
+```
+
+### Resuming from a checkpoint
+
+Pass `startPage` to resume mid-sequence, for example after a crash or for incremental syncs:
+
+```ts
+const lastSyncedPage = await db.getSyncCheckpoint(); // e.g. 42
+
+for await (const page of paginate(
+	(p) => tmdb.changes.movie_list({ page: p }),
+	lastSyncedPage + 1,
+)) {
+	await processChanges(page.results);
+}
+```
+
+### Syncing to a database in batches
+
+```ts
+for await (const page of paginate((p) => tmdb.discover.movie({ with_genres: "28", page: p }))) {
+	await db.movies.insertMany(page.results);
+}
+```
+
+---
+
+## `fetchAllPages()`
+
+Fetches all pages sequentially and returns a flat array of results. Use when you need everything
+at once and are comfortable with multiple sequential requests.
+
+```ts
+async function fetchAllPages<T>(
+	fetcher: (page: number) => Promise<PaginatedResponse<T>>,
+	options?: FetchAllPagesOptions<T>,
+): Promise<T[]>;
+```
+
+### Options
+
+| Name            | Type                   | Default | Description                                                                                           |
+| --------------- | ---------------------- | ------- | ----------------------------------------------------------------------------------------------------- |
+| `maxPages`      | `number`               | `500`   | Maximum pages to fetch. TMDB's hard cap is 500.                                                       |
+| `deduplicateBy` | `(item: T) => unknown` | —       | Key extractor for deduplication. See [note below](#duplicate-results-on-popularity-sorted-endpoints). |
+
+### Basic usage
+
+```ts
+const movies = await fetchAllPages((p) => tmdb.keywords.movies({ keyword_id: 9715, page: p }));
+```
+
+### Capping requests with `maxPages`
+
+Without a cap, `fetchAllPages` will follow `total_pages` up to the TMDB maximum of 500 pages
+(10 000 results). Use `maxPages` to constrain the total requests made:
+
+```ts
+const trending = await fetchAllPages(
+	(p) => tmdb.trending.movies({ time_window: "week", page: p }),
+	{ maxPages: 5 }, // at most 5 requests → up to 100 results
+);
+```
+
+### Duplicate results on popularity-sorted endpoints
+
+<Callout type="warn">
+	Some endpoints sort results by a **live popularity score** that changes between requests (e.g.
+	`movie_lists.now_playing`, `movie_lists.popular`, `tv_series_lists.popular`). A movie's rank can
+	shift between the time you fetch page 1 and page 2, causing the same item to appear on both page
+	boundaries. This is a known TMDB server-side behaviour — the API uses stateless offset pagination,
+	not cursors.
+</Callout>
+
+Use `deduplicateBy` to discard cross-page duplicates automatically:
+
+```ts
+const movies = await fetchAllPages((p) => tmdb.movie_lists.now_playing({ page: p }), {
+	maxPages: 3,
+	deduplicateBy: (m) => m.id,
+});
+```
+
+When two items share the same key, the **last occurrence wins** — preserving the most recently
+fetched position, which is typically the more accurate one.
+
+---
+
+## `hasNextPage()` / `hasPreviousPage()`
+
+Lightweight boolean checks for use in UI navigation and iteration logic.
+
+```ts
+function hasNextPage(response: Pick<PaginatedResponse<unknown>, "page" | "total_pages">): boolean;
+function hasPreviousPage(response: Pick<PaginatedResponse<unknown>, "page">): boolean;
+```
+
+Both accept any object with the required fields — you can pass a full `PaginatedResponse` or just
+the fields you need.
+
+```ts
+const data = await tmdb.movie_lists.popular({ page: currentPage });
+
+if (hasNextPage(data)) loadNextPage();
+if (hasPreviousPage(data)) loadPreviousPage();
+```
+
+### React pagination example
+
+```tsx
+const [page, setPage] = useState(1);
+const { data } = useQuery(["movies", page], () => tmdb.movie_lists.popular({ page }));
+
+return (
+	<>
+		{data?.results.map((m) => (
+			<MovieCard key={m.id} movie={m} />
+		))}
+		<button disabled={!data || !hasPreviousPage(data)} onClick={() => setPage((p) => p - 1)}>
+			Previous
+		</button>
+		<button disabled={!data || !hasNextPage(data)} onClick={() => setPage((p) => p + 1)}>
+			Next
+		</button>
+	</>
+);
+```
+
+---
+
+## `getPageInfo()`
+
+Extracts structured pagination metadata from any `PaginatedResponse`. Useful for building
+pagination controls or logging progress without reaching into the raw response shape.
+
+```ts
+function getPageInfo(response: PaginatedResponse<unknown>): PageInfo;
+```
+
+### `PageInfo`
+
+| Field          | Type      | Description                     |
+| -------------- | --------- | ------------------------------- |
+| `current`      | `number`  | Current page number.            |
+| `total`        | `number`  | Total number of pages.          |
+| `totalResults` | `number`  | Total results across all pages. |
+| `isFirst`      | `boolean` | `true` when on page 1.          |
+| `isLast`       | `boolean` | `true` when on the last page.   |
+
+```ts
+const info = getPageInfo(data);
+// { current: 3, total: 47, totalResults: 940, isFirst: false, isLast: false }
+```
+
+### Infinite scroll sentinel
+
+```ts
+const info = getPageInfo(lastResponse);
+if (!info.isLast) {
+	observer.observe(sentinelRef.current);
+}
+```
+
+---
+
+## Combining helpers
+
+`paginate` and `getPageInfo` compose naturally for progress logging and conditional stopping:
+
+```ts
+const collected: MovieResultItem[] = [];
+
+for await (const page of paginate((p) => tmdb.discover.movie({ with_genres: "28", page: p }))) {
+	const info = getPageInfo(page);
+	console.log(`Page ${info.current}/${info.total} — ${info.totalResults} total results`);
+
+	collected.push(...page.results);
+
+	if (collected.length >= 200 || info.isLast) break;
+}
+```

--- a/packages/tmdb/src/errors/messages.ts
+++ b/packages/tmdb/src/errors/messages.ts
@@ -6,6 +6,7 @@ export const Errors = {
 	NO_ACCESS_TOKEN: "TMDB requires a valid access token, please provide one.",
 	INVALID_CLIENT: "TMDB received an invalid ApiClient instance. Pass a valid ApiClient or an access token string.",
 	V4_REQUIRES_JWT: "TMDB v4 requires a Bearer (JWT) access token. API key strings are not supported for v4 endpoints.",
+	INVALID_START_PAGE: "Invalid page: Pages start at 1 and max at 500. They are expected to be an integer.",
 };
 
 /**

--- a/packages/tmdb/src/tests/utils/pagination.test.ts
+++ b/packages/tmdb/src/tests/utils/pagination.test.ts
@@ -1,0 +1,277 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { PaginatedResponse } from "../../types/common/pagination";
+import { fetchAllPages, getPageInfo, hasNextPage, hasPreviousPage, paginate } from "../../utils/pagination";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makePage<T>(items: T[], page: number, totalPages: number): PaginatedResponse<T> {
+	return {
+		page,
+		total_pages: totalPages,
+		total_results: totalPages * items.length,
+		results: items,
+	};
+}
+
+function mockFetcher<T>(pages: T[][]): (page: number) => Promise<PaginatedResponse<T>> {
+	return vi.fn(async (page: number) => makePage(pages[page - 1] ?? [], page, pages.length));
+}
+
+// ---------------------------------------------------------------------------
+// paginate()
+// ---------------------------------------------------------------------------
+
+describe("paginate", () => {
+	it("yields all pages in order", async () => {
+		const fetcher = mockFetcher([
+			[1, 2],
+			[3, 4],
+			[5, 6],
+		]);
+		const collected: number[][] = [];
+
+		for await (const page of paginate(fetcher)) {
+			collected.push(page.results);
+		}
+
+		expect(collected).toEqual([
+			[1, 2],
+			[3, 4],
+			[5, 6],
+		]);
+		expect(fetcher).toHaveBeenCalledTimes(3);
+	});
+
+	it("yields a single page when total_pages is 1", async () => {
+		const fetcher = mockFetcher([[1, 2, 3]]);
+		const collected: number[][] = [];
+
+		for await (const page of paginate(fetcher)) {
+			collected.push(page.results);
+		}
+
+		expect(collected).toHaveLength(1);
+		expect(collected[0]).toEqual([1, 2, 3]);
+		expect(fetcher).toHaveBeenCalledTimes(1);
+	});
+
+	it("stops early when caller breaks", async () => {
+		const fetcher = mockFetcher([[1], [2], [3], [4], [5]]);
+
+		for await (const page of paginate(fetcher)) {
+			if (page.page === 2) break;
+		}
+
+		expect(fetcher).toHaveBeenCalledTimes(2);
+	});
+
+	it("respects a custom startPage", async () => {
+		const fetcher = mockFetcher([[1], [2], [3]]);
+		const collected: number[] = [];
+
+		for await (const page of paginate(fetcher, 2)) {
+			collected.push(page.page);
+		}
+
+		expect(collected).toEqual([2, 3]);
+		expect(fetcher).not.toHaveBeenCalledWith(1);
+	});
+
+	it("handles empty results gracefully", async () => {
+		const fetcher = vi.fn(
+			async (_page: number): Promise<PaginatedResponse<number>> => ({
+				page: 1,
+				total_pages: 1,
+				total_results: 0,
+				results: [],
+			}),
+		);
+		const collected: number[][] = [];
+
+		for await (const page of paginate(fetcher)) {
+			collected.push(page.results);
+		}
+
+		expect(collected).toEqual([[]]);
+		expect(fetcher).toHaveBeenCalledTimes(1);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// fetchAllPages()
+// ---------------------------------------------------------------------------
+
+describe("fetchAllPages", () => {
+	it("collects all results into a flat array", async () => {
+		const fetcher = mockFetcher([
+			[1, 2],
+			[3, 4],
+			[5, 6],
+		]);
+		const result = await fetchAllPages(fetcher);
+
+		expect(result).toEqual([1, 2, 3, 4, 5, 6]);
+		expect(fetcher).toHaveBeenCalledTimes(3);
+	});
+
+	it("returns empty array when results are empty", async () => {
+		const fetcher = vi.fn(
+			async (_page: number): Promise<PaginatedResponse<number>> => ({
+				page: 1,
+				total_pages: 1,
+				total_results: 0,
+				results: [],
+			}),
+		);
+		const result = await fetchAllPages(fetcher);
+
+		expect(result).toEqual([]);
+	});
+
+	it("respects maxPages cap", async () => {
+		const fetcher = mockFetcher([[1], [2], [3], [4], [5]]);
+		const result = await fetchAllPages(fetcher, { maxPages: 3 });
+
+		expect(result).toEqual([1, 2, 3]);
+		expect(fetcher).toHaveBeenCalledTimes(3);
+	});
+
+	it("stops before cap when total_pages is exhausted", async () => {
+		const fetcher = mockFetcher([[1], [2]]);
+		const result = await fetchAllPages(fetcher, { maxPages: 10 });
+
+		expect(result).toEqual([1, 2]);
+		expect(fetcher).toHaveBeenCalledTimes(2);
+	});
+
+	it("defaults to TMDB cap of 500 pages", async () => {
+		// Simulate a fetcher that never reports being on the last page
+		let callCount = 0;
+		const fetcher = vi.fn(async (page: number): Promise<PaginatedResponse<number>> => {
+			callCount++;
+			return { page, total_pages: 9999, total_results: 9999, results: [page] };
+		});
+
+		const result = await fetchAllPages(fetcher);
+
+		expect(callCount).toBe(500);
+		expect(result).toHaveLength(500);
+	});
+
+	it("deduplicates results by key when deduplicateBy is provided", async () => {
+		// Simulate two pages where item name=B appears on both (TMDB popularity-shift duplicate)
+		const fetcher = vi.fn(async (page: number): Promise<PaginatedResponse<{ id: number; name: string }>> => {
+			const pages = [
+				[
+					{ id: 1, name: "A" },
+					{ id: 2, name: "B" },
+				],
+				[
+					{ id: 2, name: "B" }, // duplicate
+					{ id: 3, name: "C" },
+				],
+			];
+			return { page, total_pages: 2, total_results: 4, results: pages[page - 1] };
+		});
+
+		const result = await fetchAllPages(fetcher, { deduplicateBy: (item) => item.name });
+
+		expect(result).toHaveLength(3);
+		expect(result.map((r) => r.id)).toEqual([1, 2, 3]);
+	});
+
+	it("keeps last occurrence when key collides (Map insertion order)", async () => {
+		const fetcher = vi.fn(async (page: number): Promise<PaginatedResponse<{ id: number; page: number }>> => {
+			return { page, total_pages: 2, total_results: 2, results: [{ id: 1, page }] };
+		});
+
+		const result = await fetchAllPages(fetcher, { deduplicateBy: (item) => item.id });
+
+		expect(result).toHaveLength(1);
+		expect(result[0].page).toBe(2); // last occurrence wins
+	});
+
+	it("does not deduplicate when deduplicateBy is not provided", async () => {
+		const fetcher = mockFetcher([
+			[1, 2],
+			[2, 3],
+		]);
+		const result = await fetchAllPages(fetcher);
+
+		expect(result).toEqual([1, 2, 2, 3]); // raw duplicates preserved
+	});
+});
+
+// ---------------------------------------------------------------------------
+// hasNextPage()
+// ---------------------------------------------------------------------------
+
+describe("hasNextPage", () => {
+	it("returns true when current page is less than total_pages", () => {
+		expect(hasNextPage({ page: 1, total_pages: 3 })).toBe(true);
+		expect(hasNextPage({ page: 2, total_pages: 3 })).toBe(true);
+	});
+
+	it("returns false when on the last page", () => {
+		expect(hasNextPage({ page: 3, total_pages: 3 })).toBe(false);
+	});
+
+	it("returns false for a single-page response", () => {
+		expect(hasNextPage({ page: 1, total_pages: 1 })).toBe(false);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// hasPreviousPage()
+// ---------------------------------------------------------------------------
+
+describe("hasPreviousPage", () => {
+	it("returns true when page is greater than 1", () => {
+		expect(hasPreviousPage({ page: 2 })).toBe(true);
+		expect(hasPreviousPage({ page: 100 })).toBe(true);
+	});
+
+	it("returns false on the first page", () => {
+		expect(hasPreviousPage({ page: 1 })).toBe(false);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// getPageInfo()
+// ---------------------------------------------------------------------------
+
+describe("getPageInfo", () => {
+	it("returns correct metadata for a middle page", () => {
+		const response = makePage([1, 2], 3, 10);
+		expect(getPageInfo(response)).toEqual({
+			current: 3,
+			total: 10,
+			totalResults: 20,
+			isFirst: false,
+			isLast: false,
+		});
+	});
+
+	it("sets isFirst = true on page 1", () => {
+		const response = makePage([1], 1, 5);
+		expect(getPageInfo(response).isFirst).toBe(true);
+		expect(getPageInfo(response).isLast).toBe(false);
+	});
+
+	it("sets isLast = true on the last page", () => {
+		const response = makePage([1], 5, 5);
+		expect(getPageInfo(response).isLast).toBe(true);
+		expect(getPageInfo(response).isFirst).toBe(false);
+	});
+
+	it("sets both isFirst and isLast = true for a single-page response", () => {
+		const response = makePage([1, 2, 3], 1, 1);
+		const info = getPageInfo(response);
+		expect(info.isFirst).toBe(true);
+		expect(info.isLast).toBe(true);
+		expect(info.totalResults).toBe(3);
+	});
+});

--- a/packages/tmdb/src/tests/utils/pagination.test.ts
+++ b/packages/tmdb/src/tests/utils/pagination.test.ts
@@ -80,6 +80,33 @@ describe("paginate", () => {
 		expect(fetcher).not.toHaveBeenCalledWith(1);
 	});
 
+	it("throws RangeError for startPage = 0", async () => {
+		const fetcher = mockFetcher([[1]]);
+		await expect(async () => {
+			for await (const _page of paginate(fetcher, 0)) {
+				// should not reach here
+			}
+		}).rejects.toThrow(RangeError);
+	});
+
+	it("throws RangeError for startPage = 501 (exceeds TMDB max)", async () => {
+		const fetcher = mockFetcher([[1]]);
+		await expect(async () => {
+			for await (const _page of paginate(fetcher, 501)) {
+				// should not reach here
+			}
+		}).rejects.toThrow(RangeError);
+	});
+
+	it("throws RangeError for non-integer startPage", async () => {
+		const fetcher = mockFetcher([[1]]);
+		await expect(async () => {
+			for await (const _page of paginate(fetcher, 1.5)) {
+				// should not reach here
+			}
+		}).rejects.toThrow(RangeError);
+	});
+
 	it("handles empty results gracefully", async () => {
 		const fetcher = vi.fn(
 			async (_page: number): Promise<PaginatedResponse<number>> => ({

--- a/packages/tmdb/src/tests/utils/pagination.test.ts
+++ b/packages/tmdb/src/tests/utils/pagination.test.ts
@@ -210,7 +210,7 @@ describe("fetchAllPages", () => {
 		expect(result.map((r) => r.id)).toEqual([1, 2, 3]);
 	});
 
-	it("keeps last occurrence when key collides (Map insertion order)", async () => {
+	it("keeps last occurrence when key collides", async () => {
 		const fetcher = vi.fn(async (page: number): Promise<PaginatedResponse<{ id: number; page: number }>> => {
 			return { page, total_pages: 2, total_results: 2, results: [{ id: 1, page }] };
 		});
@@ -219,6 +219,30 @@ describe("fetchAllPages", () => {
 
 		expect(result).toHaveLength(1);
 		expect(result[0].page).toBe(2); // last occurrence wins
+	});
+
+	it("moves duplicate item to its most recently fetched position", async () => {
+		const fetcher = vi.fn(async (page: number): Promise<PaginatedResponse<{ id: number; label: string }>> => {
+			const pages = [
+				[
+					{ id: 1, label: "A-1" },
+					{ id: 2, label: "B" },
+				],
+				[
+					{ id: 3, label: "C" },
+					{ id: 1, label: "A-2" },
+				],
+			];
+			return { page, total_pages: 2, total_results: 4, results: pages[page - 1] };
+		});
+
+		const result = await fetchAllPages(fetcher, { deduplicateBy: (item) => item.id });
+
+		expect(result).toEqual([
+			{ id: 2, label: "B" },
+			{ id: 3, label: "C" },
+			{ id: 1, label: "A-2" },
+		]);
 	});
 
 	it("does not deduplicate when deduplicateBy is not provided", async () => {

--- a/packages/tmdb/src/utils/index.ts
+++ b/packages/tmdb/src/utils/index.ts
@@ -1,3 +1,4 @@
 export * from "./logger";
 export * from "./jwt";
 export * from "./types";
+export * from "./pagination";

--- a/packages/tmdb/src/utils/pagination.ts
+++ b/packages/tmdb/src/utils/pagination.ts
@@ -1,0 +1,157 @@
+import type { PaginatedResponse } from "../types/common/pagination";
+
+/** TMDB caps page numbers at 500 */
+const TMDB_MAX_PAGES = 500;
+
+/**
+ * Async generator that lazily yields one {@link PaginatedResponse} at a time.
+ *
+ * Stops automatically when all pages are consumed. The caller can `break` early
+ * to avoid unnecessary requests.
+ *
+ * @param fetcher - A function that accepts a page number and returns a promise
+ *   resolving to a {@link PaginatedResponse}.
+ * @param startPage - The page to start from (default: `1`).
+ *
+ * @example
+ * ```ts
+ * for await (const page of paginate(p => tmdb.search.movies({ query: "batman", page: p }))) {
+ *   console.log(page.results);
+ * }
+ * ```
+ */
+export async function* paginate<T>(
+	fetcher: (page: number) => Promise<PaginatedResponse<T>>,
+	startPage = 1,
+): AsyncGenerator<PaginatedResponse<T>> {
+	let page = startPage;
+	while (true) {
+		const response = await fetcher(page);
+		yield response;
+		if (response.page >= response.total_pages) break;
+		page++;
+	}
+}
+
+/**
+ * Options for {@link fetchAllPages}.
+ */
+export type FetchAllPagesOptions<T = unknown> = {
+	/**
+	 * Maximum number of pages to fetch. Defaults to `500` (the TMDB API cap).
+	 * Use this as a safety valve to avoid unbounded requests on large result sets.
+	 */
+	maxPages?: number;
+	/**
+	 * When provided, results are deduplicated using the returned key.
+	 * Useful for endpoints that use popularity-based sorting (e.g. `now_playing`),
+	 * where the same item can appear on multiple pages as rankings shift between requests.
+	 *
+	 * Defaults to `undefined` (no deduplication).
+	 *
+	 * @example
+	 * ```ts
+	 * const movies = await fetchAllPages(
+	 *   p => tmdb.movie_lists.now_playing({ page: p }),
+	 *   { deduplicateBy: m => m.id }
+	 * );
+	 * ```
+	 */
+	deduplicateBy?: (item: T) => unknown;
+};
+
+/**
+ * Fetches all pages sequentially and returns a flat array of results.
+ *
+ * @param fetcher - A function that accepts a page number and returns a promise
+ *   resolving to a {@link PaginatedResponse}.
+ * @param options - Optional settings. Use `maxPages` to cap total requests.
+ *
+ * @example
+ * ```ts
+ * const movies = await fetchAllPages(
+ *   p => tmdb.keywords.movies({ keyword_id: 9715, page: p }),
+ *   { maxPages: 5 }
+ * );
+ * ```
+ */
+export async function fetchAllPages<T>(
+	fetcher: (page: number) => Promise<PaginatedResponse<T>>,
+	options: FetchAllPagesOptions<T> = {},
+): Promise<T[]> {
+	const { maxPages = TMDB_MAX_PAGES, deduplicateBy } = options;
+	const results: T[] = [];
+	let page = 1;
+	while (true) {
+		const response = await fetcher(page);
+		results.push(...response.results);
+		if (response.page >= response.total_pages || page >= maxPages) break;
+		page++;
+	}
+	if (deduplicateBy) {
+		return [...new Map(results.map((item) => [deduplicateBy(item), item])).values()];
+	}
+	return results;
+}
+
+/**
+ * Returns `true` if there is a next page available.
+ *
+ * @example
+ * ```ts
+ * const data = await tmdb.movie_lists.popular({ page: 3 });
+ * if (hasNextPage(data)) fetchNextPage();
+ * ```
+ */
+export function hasNextPage(response: Pick<PaginatedResponse<unknown>, "page" | "total_pages">): boolean {
+	return response.page < response.total_pages;
+}
+
+/**
+ * Returns `true` if there is a previous page available.
+ *
+ * @example
+ * ```ts
+ * const data = await tmdb.movie_lists.popular({ page: 3 });
+ * if (hasPreviousPage(data)) fetchPreviousPage();
+ * ```
+ */
+export function hasPreviousPage(response: Pick<PaginatedResponse<unknown>, "page">): boolean {
+	return response.page > 1;
+}
+
+/**
+ * Structured pagination metadata extracted from a {@link PaginatedResponse}.
+ */
+export type PageInfo = {
+	/** Current page number */
+	current: number;
+	/** Total number of pages */
+	total: number;
+	/** Total number of results across all pages */
+	totalResults: number;
+	/** `true` when on the first page */
+	isFirst: boolean;
+	/** `true` when on the last page */
+	isLast: boolean;
+};
+
+/**
+ * Extracts structured pagination metadata from a {@link PaginatedResponse}.
+ * Useful for driving UI pagination controls.
+ *
+ * @example
+ * ```ts
+ * const info = getPageInfo(data);
+ * // { current: 3, total: 47, totalResults: 940, isFirst: false, isLast: false }
+ * ```
+ */
+export function getPageInfo(response: PaginatedResponse<unknown>): PageInfo {
+	return {
+		current: response.page,
+		total: response.total_pages,
+		totalResults: response.total_results,
+		isFirst: response.page === 1,
+		isLast: response.page >= response.total_pages,
+	};
+}

--- a/packages/tmdb/src/utils/pagination.ts
+++ b/packages/tmdb/src/utils/pagination.ts
@@ -50,6 +50,8 @@ export type FetchAllPagesOptions<T = unknown> = {
 	 * When provided, results are deduplicated using the returned key.
 	 * Useful for endpoints that use popularity-based sorting (e.g. `now_playing`),
 	 * where the same item can appear on multiple pages as rankings shift between requests.
+	 * When a duplicate reappears later, its later occurrence wins and is moved to that
+	 * most recently fetched position in the returned array.
 	 *
 	 * Defaults to `undefined` (no deduplication).
 	 *
@@ -93,7 +95,15 @@ export async function fetchAllPages<T>(
 		page++;
 	}
 	if (deduplicateBy) {
-		return [...new Map(results.map((item) => [deduplicateBy(item), item])).values()];
+		const deduplicated = new Map<unknown, T>();
+		for (const item of results) {
+			const key = deduplicateBy(item);
+			if (deduplicated.has(key)) {
+				deduplicated.delete(key);
+			}
+			deduplicated.set(key, item);
+		}
+		return [...deduplicated.values()];
 	}
 	return results;
 }

--- a/packages/tmdb/src/utils/pagination.ts
+++ b/packages/tmdb/src/utils/pagination.ts
@@ -1,4 +1,5 @@
 import type { PaginatedResponse } from "../types/common/pagination";
+import { Errors } from "../errors/messages";
 
 /** TMDB caps page numbers at 500 */
 const TMDB_MAX_PAGES = 500;
@@ -24,6 +25,9 @@ export async function* paginate<T>(
 	fetcher: (page: number) => Promise<PaginatedResponse<T>>,
 	startPage = 1,
 ): AsyncGenerator<PaginatedResponse<T>> {
+	if (!Number.isInteger(startPage) || startPage < 1 || startPage > TMDB_MAX_PAGES) {
+		throw new RangeError(Errors.INVALID_START_PAGE);
+	}
 	let page = startPage;
 	while (true) {
 		const response = await fetcher(page);


### PR DESCRIPTION
**Add pagination utilities**

Introduces four standalone helper functions for working with paginated TMDB responses, exported from the main package entry point.

### New helpers (`utils/pagination.ts`)

- **`paginate(fetcher, startPage?)`** — async generator that lazily yields one `PaginatedResponse<T>` at a time. Supports early `break` and resuming from a checkpoint via `startPage`.
- **`fetchAllPages(fetcher, options?)`** — collects all pages into a flat `T[]`. Accepts `maxPages` (defaults to TMDB's hard cap of 500) and `deduplicateBy` to handle cross-page duplicates caused by live popularity re-ranking on endpoints like `now_playing`.
- **`hasNextPage(response)`** / **`hasPreviousPage(response)`** — boolean checks for UI navigation; accept minimal `Pick` types so they work with any paginated response shape.
- **`getPageInfo(response)`** — returns structured metadata `{ current, total, totalResults, isFirst, isLast }` for driving pagination controls.

### Tests

22 unit tests covering all helpers, including edge cases: empty results, early generator exit, `startPage`, `maxPages` enforcement, the 500-page TMDB cap, deduplication key collision behaviour, and the no-deduplication default.

### Docs

New Pagination guide covering all four helpers with runnable examples: lazy iteration, DB batch sync, checkpoint resuming, React pagination buttons, infinite scroll sentinel, and the cross-page duplicate caveat with mitigation.