### PR TITLE
feat(movies): add watch/providers to append_to_response

### DIFF
--- a/apps/docs/content/docs/types/movies.mdx
+++ b/apps/docs/content/docs/types/movies.mdx
@@ -76,7 +76,8 @@ type MovieAppendToResponseNamespace =
 	| "reviews"
 	| "similar"
 	| "translations"
-	| "videos";
+	| "videos"
+	| "watch/providers";
 ```
 
 ---
@@ -233,6 +234,20 @@ A [`TranslationResults<MovieTranslationData>`](/docs/types/common#translationres
 	type={{
 		id: { type: "number", description: "Movie identifier." },
 		results: { type: "VideoItem[]", description: "Array of video items (trailers, teasers, clips)." },
+	}}
+/>
+
+---
+
+### `MovieWatchProviders`
+
+<TypeTable
+	type={{
+		results: {
+			type: "Record<CountryISO3166_1, WatchProvider>",
+			description: "Watch providers grouped by country code",
+			required: true,
+		},
 	}}
 />
 

--- a/packages/tmdb/src/tests/movies/movies.integration.test.ts
+++ b/packages/tmdb/src/tests/movies/movies.integration.test.ts
@@ -39,6 +39,16 @@ describe("Movies (integration)", () => {
 		expect(movie.reviews.results.length).toBeGreaterThanOrEqual(0);
 	});
 
+	it("(MOVIE DETAILS) should get movie details with watch providers appended to the response", async () => {
+		const movie_id = 550; // Fight Club
+		const movie = await tmdb.movies.details({ movie_id, append_to_response: "watch/providers" });
+		expect(movie).toBeDefined();
+		expect(movie.id).toBe(movie_id);
+		expect(movie["watch/providers"].results).toBeDefined();
+		expect(movie["watch/providers"].results["US"]).toBeDefined();
+		expect(movie["watch/providers"].results["US"].link).toBeDefined();
+	});
+
 	it("(MOVIE ALTERNATIVE TITLES) should get movie alternative titles", async () => {
 		const movie_id = 550; // Fight Club
 		const movie_titles = await tmdb.movies.alternative_titles({ movie_id });

--- a/packages/tmdb/src/types/movies.ts
+++ b/packages/tmdb/src/types/movies.ts
@@ -17,6 +17,7 @@ import {
 	TMDBQueryParams,
 	TranslationResults,
 	VideoResults,
+	WatchProvider,
 	WithLanguagePage,
 	WithParams,
 } from "./common";
@@ -98,7 +99,8 @@ export type MovieAppendToResponseNamespace =
 	| "reviews"
 	| "similar"
 	| "translations"
-	| "videos";
+	| "videos"
+	| "watch/providers";
 
 /**
  * Mapping of append-to-response keys to their return types
@@ -116,6 +118,7 @@ export type MovieAppendableMap = {
 	similar: MovieSimilar;
 	translations: MovieTranslations;
 	videos: MovieVideos;
+	"watch/providers": MovieWatchProviders;
 };
 
 /**
@@ -290,6 +293,15 @@ export type MovieTranslationData = {
  * Collection of videos (trailers, teasers, clips) for a movie
  */
 export type MovieVideos = VideoResults;
+
+// MARK: Watch Providers
+
+/**
+ * Watch provider availability for a movie across different countries
+ */
+export type MovieWatchProviders = {
+	results: Record<CountryISO3166_1, WatchProvider>;
+};
 
 // MARK: Parameters
 


### PR DESCRIPTION
This pull request adds support for the "watch/providers" append-to-response option for movie details, enabling retrieval of watch provider information grouped by country. It introduces the `MovieWatchProviders` type, updates the type mappings, and adds integration tests to ensure correct behavior.

**Support for watch providers in movie details:**

* Added `"watch/providers"` to the `MovieAppendToResponseNamespace` union type and mapped it in `MovieAppendableMap`, allowing clients to request watch provider data when fetching movie details. [[1]](diffhunk://#diff-8ebaa9b77c06a304fdb186e2973bf2c348a92e98531b58bf70c6208ab42609eeL101-R103) [[2]](diffhunk://#diff-8ebaa9b77c06a304fdb186e2973bf2c348a92e98531b58bf70c6208ab42609eeR121) [[3]](diffhunk://#diff-ee7d04b6023e58ef15f6c6ff3ca6423129f7e0b80a67fd0ea8fc9a580be128b3L79-R80)
* Introduced the `MovieWatchProviders` type, representing watch providers grouped by country code, and documented it in both code and docs. [[1]](diffhunk://#diff-8ebaa9b77c06a304fdb186e2973bf2c348a92e98531b58bf70c6208ab42609eeR297-R305) [[2]](diffhunk://#diff-ee7d04b6023e58ef15f6c6ff3ca6423129f7e0b80a67fd0ea8fc9a580be128b3R242-R255)
* Imported the `WatchProvider` type where necessary to support the new structure.

**Testing:**

* Added an integration test to verify that movie details can be fetched with watch provider information appended, ensuring the new feature works as expected.