### PR TITLE
feat(movies): add wikidata_id to external_ids

### DIFF
--- a/apps/docs/content/docs/types/movies.mdx
+++ b/apps/docs/content/docs/types/movies.mdx
@@ -120,6 +120,7 @@ Alias for [`Changes`](/docs/types/common#changes). Returns the change history fo
 	type={{
 		id: { type: "number", description: "TMDB movie identifier." },
 		imdb_id: { type: "string | null", description: 'IMDb identifier (e.g., "tt0133093").' },
+		wikidata_id: { type: "string | null", description: 'Wikidata identifier (e.g., "Q190050").' },
 		facebook_id: { type: "string | null", description: "Facebook page identifier." },
 		twitter_id: { type: "string | null", description: "Twitter/X handle." },
 		instagram_id: { type: "string | null", description: "Instagram handle." },

--- a/packages/tmdb/src/tests/movies/movies.integration.test.ts
+++ b/packages/tmdb/src/tests/movies/movies.integration.test.ts
@@ -63,6 +63,7 @@ describe("Movies (integration)", () => {
 		expect(external_ids).toBeDefined();
 		expect(external_ids.id).toBe(movie_id);
 		expect(external_ids.imdb_id).toBe("tt0137523");
+		expect(external_ids.wikidata_id).toBe("Q190050");
 	});
 
 	it("(MOVIE KEYWORDS) should get movie keywords", async () => {

--- a/packages/tmdb/src/types/movies.ts
+++ b/packages/tmdb/src/types/movies.ts
@@ -173,6 +173,8 @@ export type MovieExternalIDs = {
 	id: number;
 	/** IMDb identifier (e.g., "tt0133093"), null if not available */
 	imdb_id?: string;
+	/** Wikidata identifier (e.g., "Q190050"), null if not available */
+	wikidata_id?: string;
 	/** Facebook page identifier, null if not available */
 	facebook_id?: string;
 	/** Twitter/X handle, null if not available */


### PR DESCRIPTION
This pull request adds support for the Wikidata identifier to movie external IDs across the codebase. The main changes ensure that the new `wikidata_id` field is available in type definitions, documentation, and is covered by integration tests.

**Type and API updates:**

* Added an optional `wikidata_id` field to the `MovieExternalIDs` type in `packages/tmdb/src/types/movies.ts`, allowing movies to include a Wikidata identifier if available.

**Documentation updates:**

* Updated the movies type documentation in `apps/docs/content/docs/types/movies.mdx` to include the new `wikidata_id` field, with a description and example.

**Testing updates:**

* Enhanced the movies integration test in `packages/tmdb/src/tests/movies/movies.integration.test.ts` to assert that the `wikidata_id` is correctly returned for a movie.