### PR TITLE
fix(trending): add page param to all trending endpoints

### DIFF
--- a/apps/docs/content/docs/api-reference/trending/all.mdx
+++ b/apps/docs/content/docs/api-reference/trending/all.mdx
@@ -18,6 +18,7 @@ async all(params: TrendingParams): Promise<PaginatedResponse<TrendingAllResult>>
 | ------------- | --------------------------------------------------------------- | -------- | ------------------------------------------------------------------------------------------------- |
 | `time_window` | [`TrendingTimeWindow`](/docs/types/trending#trendingtimewindow) | ✅       | Time window for trending data. `"day"` covers the last 24 hours, `"week"` covers the last 7 days. |
 | `language`    | [`Language`](/docs/types/options/language#language)             | ❌       | Language for localized results. Defaults to `en-US`.                                              |
+| `page`        | `number`                                                        | ❌       | Page number. Defaults to `1`.                                                                     |
 
 ## Returns
 

--- a/apps/docs/content/docs/api-reference/trending/movies.mdx
+++ b/apps/docs/content/docs/api-reference/trending/movies.mdx
@@ -17,6 +17,7 @@ async movies(params: TrendingParams): Promise<PaginatedResponse<TrendingMovieRes
 | ------------- | --------------------------------------------------------------- | -------- | ------------------------------------------------------------------------------------------------- |
 | `time_window` | [`TrendingTimeWindow`](/docs/types/trending#trendingtimewindow) | ✅       | Time window for trending data. `"day"` covers the last 24 hours, `"week"` covers the last 7 days. |
 | `language`    | [`Language`](/docs/types/options/language#language)             | ❌       | Language for localized results. Defaults to `en-US`.                                              |
+| `page`        | `number`                                                        | ❌       | Page number. Defaults to `1`.                                                                     |
 
 ## Returns
 

--- a/apps/docs/content/docs/api-reference/trending/people.mdx
+++ b/apps/docs/content/docs/api-reference/trending/people.mdx
@@ -17,6 +17,7 @@ async people(params: TrendingParams): Promise<PaginatedResponse<TrendingPersonRe
 | ------------- | --------------------------------------------------------------- | -------- | ------------------------------------------------------------------------------------------------- |
 | `time_window` | [`TrendingTimeWindow`](/docs/types/trending#trendingtimewindow) | ✅       | Time window for trending data. `"day"` covers the last 24 hours, `"week"` covers the last 7 days. |
 | `language`    | [`Language`](/docs/types/options/language#language)             | ❌       | Language for localized results. Defaults to `en-US`.                                              |
+| `page`        | `number`                                                        | ❌       | Page number. Defaults to `1`.                                                                     |
 
 ## Returns
 

--- a/apps/docs/content/docs/api-reference/trending/tv.mdx
+++ b/apps/docs/content/docs/api-reference/trending/tv.mdx
@@ -17,6 +17,7 @@ async tv(params: TrendingParams): Promise<PaginatedResponse<TrendingTVResult>>
 | ------------- | --------------------------------------------------------------- | -------- | ------------------------------------------------------------------------------------------------- |
 | `time_window` | [`TrendingTimeWindow`](/docs/types/trending#trendingtimewindow) | ✅       | Time window for trending data. `"day"` covers the last 24 hours, `"week"` covers the last 7 days. |
 | `language`    | [`Language`](/docs/types/options/language#language)             | ❌       | Language for localized results. Defaults to `en-US`.                                              |
+| `page`        | `number`                                                        | ❌       | Page number. Defaults to `1`.                                                                     |
 
 ## Returns
 

--- a/apps/docs/content/docs/types/trending.mdx
+++ b/apps/docs/content/docs/types/trending.mdx
@@ -23,6 +23,7 @@ type TrendingTimeWindow = "day" | "week";
 			required: true,
 		},
 		language: { type: "Language", description: "Language for localised results.", default: "en-US" },
+		page: { type: "number", description: "Page number.", default: "1" },
 	}}
 />
 

--- a/packages/tmdb/src/endpoints/trending.ts
+++ b/packages/tmdb/src/endpoints/trending.ts
@@ -18,8 +18,8 @@ export class TrendingAPI extends TMDBAPIBase {
 	 * @reference https://developer.themoviedb.org/reference/trending-all
 	 */
 	async all(params: TrendingParams): Promise<PaginatedResponse<TrendingAllResult>> {
-		const { time_window, language = this.defaultOptions.language } = params;
-		return this.client.request<PaginatedResponse<TrendingAllResult>>(`${ENDPOINTS.TRENDING.ALL}/${time_window}`, { language });
+		const { time_window, language = this.defaultOptions.language, page } = params;
+		return this.client.request<PaginatedResponse<TrendingAllResult>>(`${ENDPOINTS.TRENDING.ALL}/${time_window}`, { language, page });
 	}
 
 	/**
@@ -30,8 +30,8 @@ export class TrendingAPI extends TMDBAPIBase {
 	 * @reference https://developer.themoviedb.org/reference/trending-movies
 	 */
 	async movies(params: TrendingParams): Promise<PaginatedResponse<TrendingMovieResult>> {
-		const { time_window, language = this.defaultOptions.language } = params;
-		return this.client.request<PaginatedResponse<TrendingMovieResult>>(`${ENDPOINTS.TRENDING.MOVIE}/${time_window}`, { language });
+		const { time_window, language = this.defaultOptions.language, page } = params;
+		return this.client.request<PaginatedResponse<TrendingMovieResult>>(`${ENDPOINTS.TRENDING.MOVIE}/${time_window}`, { language, page });
 	}
 
 	/**
@@ -42,8 +42,8 @@ export class TrendingAPI extends TMDBAPIBase {
 	 * @reference https://developer.themoviedb.org/reference/trending-tv
 	 */
 	async tv(params: TrendingParams): Promise<PaginatedResponse<TrendingTVResult>> {
-		const { time_window, language = this.defaultOptions.language } = params;
-		return this.client.request<PaginatedResponse<TrendingTVResult>>(`${ENDPOINTS.TRENDING.TV}/${time_window}`, { language });
+		const { time_window, language = this.defaultOptions.language, page } = params;
+		return this.client.request<PaginatedResponse<TrendingTVResult>>(`${ENDPOINTS.TRENDING.TV}/${time_window}`, { language, page });
 	}
 
 	/**
@@ -54,7 +54,7 @@ export class TrendingAPI extends TMDBAPIBase {
 	 * @reference https://developer.themoviedb.org/reference/trending-people
 	 */
 	async people(params: TrendingParams): Promise<PaginatedResponse<TrendingPersonResult>> {
-		const { time_window, language = this.defaultOptions.language } = params;
-		return this.client.request<PaginatedResponse<TrendingPersonResult>>(`${ENDPOINTS.TRENDING.PERSON}/${time_window}`, { language });
+		const { time_window, language = this.defaultOptions.language, page } = params;
+		return this.client.request<PaginatedResponse<TrendingPersonResult>>(`${ENDPOINTS.TRENDING.PERSON}/${time_window}`, { language, page });
 	}
 }

--- a/packages/tmdb/src/endpoints/trending.ts
+++ b/packages/tmdb/src/endpoints/trending.ts
@@ -18,8 +18,8 @@ export class TrendingAPI extends TMDBAPIBase {
 	 * @reference https://developer.themoviedb.org/reference/trending-all
 	 */
 	async all(params: TrendingParams): Promise<PaginatedResponse<TrendingAllResult>> {
-		const { time_window, language = this.defaultOptions.language, page } = params;
-		return this.client.request<PaginatedResponse<TrendingAllResult>>(`${ENDPOINTS.TRENDING.ALL}/${time_window}`, { language, page });
+		const { time_window, language = this.defaultOptions.language, ...rest } = params;
+		return this.client.request<PaginatedResponse<TrendingAllResult>>(`${ENDPOINTS.TRENDING.ALL}/${time_window}`, { language, ...rest });
 	}
 
 	/**
@@ -30,8 +30,8 @@ export class TrendingAPI extends TMDBAPIBase {
 	 * @reference https://developer.themoviedb.org/reference/trending-movies
 	 */
 	async movies(params: TrendingParams): Promise<PaginatedResponse<TrendingMovieResult>> {
-		const { time_window, language = this.defaultOptions.language, page } = params;
-		return this.client.request<PaginatedResponse<TrendingMovieResult>>(`${ENDPOINTS.TRENDING.MOVIE}/${time_window}`, { language, page });
+		const { time_window, language = this.defaultOptions.language, ...rest } = params;
+		return this.client.request<PaginatedResponse<TrendingMovieResult>>(`${ENDPOINTS.TRENDING.MOVIE}/${time_window}`, { language, ...rest });
 	}
 
 	/**
@@ -42,8 +42,8 @@ export class TrendingAPI extends TMDBAPIBase {
 	 * @reference https://developer.themoviedb.org/reference/trending-tv
 	 */
 	async tv(params: TrendingParams): Promise<PaginatedResponse<TrendingTVResult>> {
-		const { time_window, language = this.defaultOptions.language, page } = params;
-		return this.client.request<PaginatedResponse<TrendingTVResult>>(`${ENDPOINTS.TRENDING.TV}/${time_window}`, { language, page });
+		const { time_window, language = this.defaultOptions.language, ...rest } = params;
+		return this.client.request<PaginatedResponse<TrendingTVResult>>(`${ENDPOINTS.TRENDING.TV}/${time_window}`, { language, ...rest });
 	}
 
 	/**
@@ -54,7 +54,7 @@ export class TrendingAPI extends TMDBAPIBase {
 	 * @reference https://developer.themoviedb.org/reference/trending-people
 	 */
 	async people(params: TrendingParams): Promise<PaginatedResponse<TrendingPersonResult>> {
-		const { time_window, language = this.defaultOptions.language, page } = params;
-		return this.client.request<PaginatedResponse<TrendingPersonResult>>(`${ENDPOINTS.TRENDING.PERSON}/${time_window}`, { language, page });
+		const { time_window, language = this.defaultOptions.language, ...rest } = params;
+		return this.client.request<PaginatedResponse<TrendingPersonResult>>(`${ENDPOINTS.TRENDING.PERSON}/${time_window}`, { language, ...rest });
 	}
 }

--- a/packages/tmdb/src/endpoints/trending.ts
+++ b/packages/tmdb/src/endpoints/trending.ts
@@ -19,7 +19,10 @@ export class TrendingAPI extends TMDBAPIBase {
 	 */
 	async all(params: TrendingParams): Promise<PaginatedResponse<TrendingAllResult>> {
 		const { time_window, language = this.defaultOptions.language, ...rest } = params;
-		return this.client.request<PaginatedResponse<TrendingAllResult>>(`${ENDPOINTS.TRENDING.ALL}/${time_window}`, { language, ...rest });
+		return this.client.request<PaginatedResponse<TrendingAllResult>>(
+			`${ENDPOINTS.TRENDING.ALL}/${time_window}`,
+			{ language, ...rest },
+		);
 	}
 
 	/**
@@ -31,7 +34,10 @@ export class TrendingAPI extends TMDBAPIBase {
 	 */
 	async movies(params: TrendingParams): Promise<PaginatedResponse<TrendingMovieResult>> {
 		const { time_window, language = this.defaultOptions.language, ...rest } = params;
-		return this.client.request<PaginatedResponse<TrendingMovieResult>>(`${ENDPOINTS.TRENDING.MOVIE}/${time_window}`, { language, ...rest });
+		return this.client.request<PaginatedResponse<TrendingMovieResult>>(
+			`${ENDPOINTS.TRENDING.MOVIE}/${time_window}`,
+			{ language, ...rest },
+		);
 	}
 
 	/**
@@ -43,7 +49,10 @@ export class TrendingAPI extends TMDBAPIBase {
 	 */
 	async tv(params: TrendingParams): Promise<PaginatedResponse<TrendingTVResult>> {
 		const { time_window, language = this.defaultOptions.language, ...rest } = params;
-		return this.client.request<PaginatedResponse<TrendingTVResult>>(`${ENDPOINTS.TRENDING.TV}/${time_window}`, { language, ...rest });
+		return this.client.request<PaginatedResponse<TrendingTVResult>>(
+			`${ENDPOINTS.TRENDING.TV}/${time_window}`,
+			{ language, ...rest },
+		);
 	}
 
 	/**
@@ -55,6 +64,9 @@ export class TrendingAPI extends TMDBAPIBase {
 	 */
 	async people(params: TrendingParams): Promise<PaginatedResponse<TrendingPersonResult>> {
 		const { time_window, language = this.defaultOptions.language, ...rest } = params;
-		return this.client.request<PaginatedResponse<TrendingPersonResult>>(`${ENDPOINTS.TRENDING.PERSON}/${time_window}`, { language, ...rest });
+		return this.client.request<PaginatedResponse<TrendingPersonResult>>(
+			`${ENDPOINTS.TRENDING.PERSON}/${time_window}`,
+			{ language, ...rest },
+		);
 	}
 }

--- a/packages/tmdb/src/tests/trending/trending.test.ts
+++ b/packages/tmdb/src/tests/trending/trending.test.ts
@@ -27,7 +27,7 @@ describe("TrendingAPI", () => {
 
 		it("should pass the language param as a query param", async () => {
 			await trendingAPI.all({ time_window: "day", language: "fr-FR" });
-			expect(clientMock.request).toHaveBeenCalledWith("/trending/all/day", { language: "fr-FR", page: undefined });
+			expect(clientMock.request).toHaveBeenCalledWith("/trending/all/day", { language: "fr-FR" });
 		});
 
 		it("should pass the page param as a query param", async () => {
@@ -63,7 +63,7 @@ describe("TrendingAPI", () => {
 
 		it("should pass the language param as a query param", async () => {
 			await trendingAPI.movies({ time_window: "day", language: "es-ES" });
-			expect(clientMock.request).toHaveBeenCalledWith("/trending/movie/day", { language: "es-ES", page: undefined });
+			expect(clientMock.request).toHaveBeenCalledWith("/trending/movie/day", { language: "es-ES" });
 		});
 
 		it("should pass the page param as a query param", async () => {
@@ -104,7 +104,7 @@ describe("TrendingAPI", () => {
 
 		it("should pass the language param as a query param", async () => {
 			await trendingAPI.tv({ time_window: "day", language: "ja-JP" });
-			expect(clientMock.request).toHaveBeenCalledWith("/trending/tv/day", { language: "ja-JP", page: undefined });
+			expect(clientMock.request).toHaveBeenCalledWith("/trending/tv/day", { language: "ja-JP" });
 		});
 
 		it("should pass the page param as a query param", async () => {
@@ -139,7 +139,7 @@ describe("TrendingAPI", () => {
 
 		it("should pass the language param as a query param", async () => {
 			await trendingAPI.people({ time_window: "week", language: "ko-KR" });
-			expect(clientMock.request).toHaveBeenCalledWith("/trending/person/week", { language: "ko-KR", page: undefined });
+			expect(clientMock.request).toHaveBeenCalledWith("/trending/person/week", { language: "ko-KR" });
 		});
 
 		it("should pass the page param as a query param", async () => {

--- a/packages/tmdb/src/tests/trending/trending.test.ts
+++ b/packages/tmdb/src/tests/trending/trending.test.ts
@@ -22,7 +22,9 @@ describe("TrendingAPI", () => {
 
 		it("should call client.request with the correct endpoint for time_window=week", async () => {
 			await trendingAPI.all({ time_window: "week" });
-			expect(clientMock.request).toHaveBeenCalledWith("/trending/all/week", { language: undefined });
+			expect(clientMock.request).toHaveBeenCalledWith("/trending/all/week", {
+				language: undefined,
+			});
 		});
 
 		it("should pass the language param as a query param", async () => {
@@ -32,7 +34,10 @@ describe("TrendingAPI", () => {
 
 		it("should pass the page param as a query param", async () => {
 			await trendingAPI.all({ time_window: "day", page: 2 });
-			expect(clientMock.request).toHaveBeenCalledWith("/trending/all/day", { language: undefined, page: 2 });
+			expect(clientMock.request).toHaveBeenCalledWith("/trending/all/day", {
+				language: undefined,
+				page: 2,
+			});
 		});
 
 		it("should use defaultOptions.language when no language param provided", async () => {
@@ -53,12 +58,16 @@ describe("TrendingAPI", () => {
 	describe("movies()", () => {
 		it("should call client.request with the correct endpoint for time_window=day", async () => {
 			await trendingAPI.movies({ time_window: "day" });
-			expect(clientMock.request).toHaveBeenCalledWith("/trending/movie/day", { language: undefined });
+			expect(clientMock.request).toHaveBeenCalledWith("/trending/movie/day", {
+				language: undefined,
+			});
 		});
 
 		it("should call client.request with the correct endpoint for time_window=week", async () => {
 			await trendingAPI.movies({ time_window: "week" });
-			expect(clientMock.request).toHaveBeenCalledWith("/trending/movie/week", { language: undefined });
+			expect(clientMock.request).toHaveBeenCalledWith("/trending/movie/week", {
+				language: undefined,
+			});
 		});
 
 		it("should pass the language param as a query param", async () => {
@@ -68,13 +77,18 @@ describe("TrendingAPI", () => {
 
 		it("should pass the page param as a query param", async () => {
 			await trendingAPI.movies({ time_window: "day", page: 3 });
-			expect(clientMock.request).toHaveBeenCalledWith("/trending/movie/day", { language: undefined, page: 3 });
+			expect(clientMock.request).toHaveBeenCalledWith("/trending/movie/day", {
+				language: undefined,
+				page: 3,
+			});
 		});
 
 		it("should use defaultOptions.language when no language param provided", async () => {
 			trendingAPI = new TrendingAPI(clientMock, { language: "de-DE" });
 			await trendingAPI.movies({ time_window: "week" });
-			expect(clientMock.request).toHaveBeenCalledWith("/trending/movie/week", { language: "de-DE" });
+			expect(clientMock.request).toHaveBeenCalledWith("/trending/movie/week", {
+				language: "de-DE",
+			});
 		});
 
 		it("should return the result from client.request", async () => {
@@ -109,7 +123,10 @@ describe("TrendingAPI", () => {
 
 		it("should pass the page param as a query param", async () => {
 			await trendingAPI.tv({ time_window: "day", page: 4 });
-			expect(clientMock.request).toHaveBeenCalledWith("/trending/tv/day", { language: undefined, page: 4 });
+			expect(clientMock.request).toHaveBeenCalledWith("/trending/tv/day", {
+				language: undefined,
+				page: 4,
+			});
 		});
 
 		it("should return the result from client.request", async () => {
@@ -129,22 +146,31 @@ describe("TrendingAPI", () => {
 	describe("people()", () => {
 		it("should call client.request with the correct endpoint for time_window=day", async () => {
 			await trendingAPI.people({ time_window: "day" });
-			expect(clientMock.request).toHaveBeenCalledWith("/trending/person/day", { language: undefined });
+			expect(clientMock.request).toHaveBeenCalledWith("/trending/person/day", {
+				language: undefined,
+			});
 		});
 
 		it("should call client.request with the correct endpoint for time_window=week", async () => {
 			await trendingAPI.people({ time_window: "week" });
-			expect(clientMock.request).toHaveBeenCalledWith("/trending/person/week", { language: undefined });
+			expect(clientMock.request).toHaveBeenCalledWith("/trending/person/week", {
+				language: undefined,
+			});
 		});
 
 		it("should pass the language param as a query param", async () => {
 			await trendingAPI.people({ time_window: "week", language: "ko-KR" });
-			expect(clientMock.request).toHaveBeenCalledWith("/trending/person/week", { language: "ko-KR" });
+			expect(clientMock.request).toHaveBeenCalledWith("/trending/person/week", {
+				language: "ko-KR",
+			});
 		});
 
 		it("should pass the page param as a query param", async () => {
 			await trendingAPI.people({ time_window: "week", page: 5 });
-			expect(clientMock.request).toHaveBeenCalledWith("/trending/person/week", { language: undefined, page: 5 });
+			expect(clientMock.request).toHaveBeenCalledWith("/trending/person/week", {
+				language: undefined,
+				page: 5,
+			});
 		});
 
 		it("should return the result from client.request", async () => {

--- a/packages/tmdb/src/tests/trending/trending.test.ts
+++ b/packages/tmdb/src/tests/trending/trending.test.ts
@@ -27,7 +27,12 @@ describe("TrendingAPI", () => {
 
 		it("should pass the language param as a query param", async () => {
 			await trendingAPI.all({ time_window: "day", language: "fr-FR" });
-			expect(clientMock.request).toHaveBeenCalledWith("/trending/all/day", { language: "fr-FR" });
+			expect(clientMock.request).toHaveBeenCalledWith("/trending/all/day", { language: "fr-FR", page: undefined });
+		});
+
+		it("should pass the page param as a query param", async () => {
+			await trendingAPI.all({ time_window: "day", page: 2 });
+			expect(clientMock.request).toHaveBeenCalledWith("/trending/all/day", { language: undefined, page: 2 });
 		});
 
 		it("should use defaultOptions.language when no language param provided", async () => {
@@ -58,7 +63,12 @@ describe("TrendingAPI", () => {
 
 		it("should pass the language param as a query param", async () => {
 			await trendingAPI.movies({ time_window: "day", language: "es-ES" });
-			expect(clientMock.request).toHaveBeenCalledWith("/trending/movie/day", { language: "es-ES" });
+			expect(clientMock.request).toHaveBeenCalledWith("/trending/movie/day", { language: "es-ES", page: undefined });
+		});
+
+		it("should pass the page param as a query param", async () => {
+			await trendingAPI.movies({ time_window: "day", page: 3 });
+			expect(clientMock.request).toHaveBeenCalledWith("/trending/movie/day", { language: undefined, page: 3 });
 		});
 
 		it("should use defaultOptions.language when no language param provided", async () => {
@@ -94,7 +104,12 @@ describe("TrendingAPI", () => {
 
 		it("should pass the language param as a query param", async () => {
 			await trendingAPI.tv({ time_window: "day", language: "ja-JP" });
-			expect(clientMock.request).toHaveBeenCalledWith("/trending/tv/day", { language: "ja-JP" });
+			expect(clientMock.request).toHaveBeenCalledWith("/trending/tv/day", { language: "ja-JP", page: undefined });
+		});
+
+		it("should pass the page param as a query param", async () => {
+			await trendingAPI.tv({ time_window: "day", page: 4 });
+			expect(clientMock.request).toHaveBeenCalledWith("/trending/tv/day", { language: undefined, page: 4 });
 		});
 
 		it("should return the result from client.request", async () => {
@@ -124,7 +139,12 @@ describe("TrendingAPI", () => {
 
 		it("should pass the language param as a query param", async () => {
 			await trendingAPI.people({ time_window: "week", language: "ko-KR" });
-			expect(clientMock.request).toHaveBeenCalledWith("/trending/person/week", { language: "ko-KR" });
+			expect(clientMock.request).toHaveBeenCalledWith("/trending/person/week", { language: "ko-KR", page: undefined });
+		});
+
+		it("should pass the page param as a query param", async () => {
+			await trendingAPI.people({ time_window: "week", page: 5 });
+			expect(clientMock.request).toHaveBeenCalledWith("/trending/person/week", { language: undefined, page: 5 });
 		});
 
 		it("should return the result from client.request", async () => {

--- a/packages/tmdb/src/types/trending.ts
+++ b/packages/tmdb/src/types/trending.ts
@@ -13,6 +13,8 @@ export type TrendingParams = {
 	time_window: TrendingTimeWindow;
 	/** Language for localised results (ISO 639-1 + ISO 3166-1, e.g. `"en-US"`). */
 	language?: Language;
+	/** Page number. Defaults to 1. */
+	page?: number;
 };
 
 /**


### PR DESCRIPTION
## Summary

- Added `page?: number` to `TrendingParams` type
- All 4 trending methods (`all`, `movies`, `tv`, `people`) now forward `page` to the API
- Updated docs parameter tables and `TrendingParams` type table

## Notes

TMDB trending endpoints support pagination even though official docs don't list the `page` param.

Closes #117