### PR TITLE
fix(tv-series): add missing append_to_response values to TVAppendToResponseNamespace

### DIFF
--- a/apps/docs/content/docs/api-reference/tv-series/details.mdx
+++ b/apps/docs/content/docs/api-reference/tv-series/details.mdx
@@ -36,8 +36,10 @@ console.log(show.name); // "Breaking Bad"
 // With appended data
 const show = await tmdb.tv_series.details({
 	series_id: 1396,
-	append_to_response: ["credits", "videos", "keywords"],
+	append_to_response: ["credits", "videos", "content_ratings", "watch/providers"],
 });
 console.log(show.credits.cast);
 console.log(show.videos.results);
+console.log(show.content_ratings.results);
+console.log(show["watch/providers"].results);
 ```

--- a/apps/docs/content/docs/types/tv-series.mdx
+++ b/apps/docs/content/docs/types/tv-series.mdx
@@ -35,15 +35,25 @@ Union of all valid keys that can be passed to `append_to_response`.
 
 ```ts
 type TVAppendToResponseNamespace =
+	| "aggregate_credits"
+	| "alternative_titles"
+	| "content_ratings"
 	| "credits"
+	| "episode_groups"
 	| "external_ids"
 	| "images"
 	| "keywords"
+	| "lists"
 	| "recommendations"
+	| "reviews"
+	| "screened_theatrically"
 	| "similar"
 	| "translations"
-	| "videos";
+	| "videos"
+	| "watch/providers";
 ```
+
+> **Note:** `watch/providers` uses a slash because it maps to the `/tv/{series_id}/watch/providers` sub-path. Access the appended data with `show["watch/providers"]`.
 
 ---
 

--- a/apps/docs/content/docs/types/tv-series.mdx
+++ b/apps/docs/content/docs/types/tv-series.mdx
@@ -37,6 +37,7 @@ Union of all valid keys that can be passed to `append_to_response`.
 type TVAppendToResponseNamespace =
 	| "aggregate_credits"
 	| "alternative_titles"
+	| "changes"
 	| "content_ratings"
 	| "credits"
 	| "episode_groups"

--- a/packages/tmdb/src/tests/tv_series/tv_series.details.integration.test.ts
+++ b/packages/tmdb/src/tests/tv_series/tv_series.details.integration.test.ts
@@ -41,4 +41,58 @@ describe("TV Series Details (integration)", () => {
 		expect(show.translations).toBeDefined();
 		expect(show.videos).toBeDefined();
 	});
+
+	it("(DETAILS + append: aggregate_credits) should include aggregate_credits", async () => {
+		const show = await tmdb.tv_series.details({ series_id: 1396, append_to_response: ["aggregate_credits"] });
+		expect(show.aggregate_credits).toBeDefined();
+		expect(Array.isArray(show.aggregate_credits.cast)).toBe(true);
+		expect(Array.isArray(show.aggregate_credits.crew)).toBe(true);
+		expect(show.aggregate_credits.cast.length).toBeGreaterThan(0);
+	});
+
+	it("(DETAILS + append: alternative_titles) should include alternative_titles", async () => {
+		const show = await tmdb.tv_series.details({ series_id: 1396, append_to_response: ["alternative_titles"] });
+		expect(show.alternative_titles).toBeDefined();
+		expect(Array.isArray(show.alternative_titles.results)).toBe(true);
+		expect(show.alternative_titles.results.length).toBeGreaterThan(0);
+	});
+
+	it("(DETAILS + append: content_ratings) should include content_ratings", async () => {
+		const show = await tmdb.tv_series.details({ series_id: 1396, append_to_response: ["content_ratings"] });
+		expect(show.content_ratings).toBeDefined();
+		expect(Array.isArray(show.content_ratings.results)).toBe(true);
+		expect(show.content_ratings.results.length).toBeGreaterThan(0);
+	});
+
+	it("(DETAILS + append: episode_groups) should include episode_groups", async () => {
+		const show = await tmdb.tv_series.details({ series_id: 1399, append_to_response: ["episode_groups"] });
+		expect(show.episode_groups).toBeDefined();
+		expect(Array.isArray(show.episode_groups.results)).toBe(true);
+		expect(show.episode_groups.results.length).toBeGreaterThan(0);
+	});
+
+	it("(DETAILS + append: lists) should include lists", async () => {
+		const show = await tmdb.tv_series.details({ series_id: 1399, append_to_response: ["lists"] });
+		expect(show.lists).toBeDefined();
+		expect(Array.isArray(show.lists.results)).toBe(true);
+	});
+
+	it("(DETAILS + append: reviews) should include reviews", async () => {
+		const show = await tmdb.tv_series.details({ series_id: 1399, append_to_response: ["reviews"] });
+		expect(show.reviews).toBeDefined();
+		expect(Array.isArray(show.reviews.results)).toBe(true);
+		expect(show.reviews.results.length).toBeGreaterThan(0);
+	});
+
+	it("(DETAILS + append: screened_theatrically) should include screened_theatrically", async () => {
+		const show = await tmdb.tv_series.details({ series_id: 1399, append_to_response: ["screened_theatrically"] });
+		expect(show.screened_theatrically).toBeDefined();
+		expect(Array.isArray(show.screened_theatrically.results)).toBe(true);
+	});
+
+	it("(DETAILS + append: watch/providers) should include watch_providers", async () => {
+		const show = await tmdb.tv_series.details({ series_id: 1399, append_to_response: ["watch/providers"] });
+		expect(show["watch/providers"]).toBeDefined();
+		expect(show["watch/providers"].results).toBeDefined();
+	});
 });

--- a/packages/tmdb/src/tests/tv_series/tv_series.details.integration.test.ts
+++ b/packages/tmdb/src/tests/tv_series/tv_series.details.integration.test.ts
@@ -1,5 +1,5 @@
 import { TMDB } from "../../tmdb";
-import { describe, expect, it } from "vitest";
+import { beforeAll, describe, expect, it } from "vitest";
 
 const token = process.env.TMDB_BEARER_TOKEN;
 if (!token) throw new Error("TMDB_BEARER_TOKEN is not set, please set it in your enviroment variables.");
@@ -7,6 +7,16 @@ if (!token) throw new Error("TMDB_BEARER_TOKEN is not set, please set it in your
 const tmdb = new TMDB(token, { language: "en-US", region: "US", timezone: "Europe/Rome" });
 
 describe("TV Series Details (integration)", () => {
+	let show1396: Awaited<ReturnType<typeof tmdb.tv_series.details<["aggregate_credits", "alternative_titles", "content_ratings"]>>>;
+	let show1399: Awaited<ReturnType<typeof tmdb.tv_series.details<["episode_groups", "lists", "reviews", "screened_theatrically", "watch/providers"]>>>;
+
+	beforeAll(async () => {
+		[show1396, show1399] = await Promise.all([
+			tmdb.tv_series.details({ series_id: 1396, append_to_response: ["aggregate_credits", "alternative_titles", "content_ratings"] }),
+			tmdb.tv_series.details({ series_id: 1399, append_to_response: ["episode_groups", "lists", "reviews", "screened_theatrically", "watch/providers"] }),
+		]);
+	});
+
 	it("(DETAILS) should fetch top-level details for a TV series", async () => {
 		const show = await tmdb.tv_series.details({ series_id: 1396 });
 		expect(show.id).toBe(1396);
@@ -42,57 +52,49 @@ describe("TV Series Details (integration)", () => {
 		expect(show.videos).toBeDefined();
 	});
 
-	it("(DETAILS + append: aggregate_credits) should include aggregate_credits", async () => {
-		const show = await tmdb.tv_series.details({ series_id: 1396, append_to_response: ["aggregate_credits"] });
-		expect(show.aggregate_credits).toBeDefined();
-		expect(Array.isArray(show.aggregate_credits.cast)).toBe(true);
-		expect(Array.isArray(show.aggregate_credits.crew)).toBe(true);
-		expect(show.aggregate_credits.cast.length).toBeGreaterThan(0);
+	it("(DETAILS + append: aggregate_credits) should include aggregate_credits", () => {
+		expect(show1396.aggregate_credits).toBeDefined();
+		expect(Array.isArray(show1396.aggregate_credits.cast)).toBe(true);
+		expect(Array.isArray(show1396.aggregate_credits.crew)).toBe(true);
+		expect(show1396.aggregate_credits.cast.length).toBeGreaterThan(0);
 	});
 
-	it("(DETAILS + append: alternative_titles) should include alternative_titles", async () => {
-		const show = await tmdb.tv_series.details({ series_id: 1396, append_to_response: ["alternative_titles"] });
-		expect(show.alternative_titles).toBeDefined();
-		expect(Array.isArray(show.alternative_titles.results)).toBe(true);
-		expect(show.alternative_titles.results.length).toBeGreaterThan(0);
+	it("(DETAILS + append: alternative_titles) should include alternative_titles", () => {
+		expect(show1396.alternative_titles).toBeDefined();
+		expect(Array.isArray(show1396.alternative_titles.results)).toBe(true);
+		expect(show1396.alternative_titles.results.length).toBeGreaterThan(0);
 	});
 
-	it("(DETAILS + append: content_ratings) should include content_ratings", async () => {
-		const show = await tmdb.tv_series.details({ series_id: 1396, append_to_response: ["content_ratings"] });
-		expect(show.content_ratings).toBeDefined();
-		expect(Array.isArray(show.content_ratings.results)).toBe(true);
-		expect(show.content_ratings.results.length).toBeGreaterThan(0);
+	it("(DETAILS + append: content_ratings) should include content_ratings", () => {
+		expect(show1396.content_ratings).toBeDefined();
+		expect(Array.isArray(show1396.content_ratings.results)).toBe(true);
+		expect(show1396.content_ratings.results.length).toBeGreaterThan(0);
 	});
 
-	it("(DETAILS + append: episode_groups) should include episode_groups", async () => {
-		const show = await tmdb.tv_series.details({ series_id: 1399, append_to_response: ["episode_groups"] });
-		expect(show.episode_groups).toBeDefined();
-		expect(Array.isArray(show.episode_groups.results)).toBe(true);
-		expect(show.episode_groups.results.length).toBeGreaterThan(0);
+	it("(DETAILS + append: episode_groups) should include episode_groups", () => {
+		expect(show1399.episode_groups).toBeDefined();
+		expect(Array.isArray(show1399.episode_groups.results)).toBe(true);
+		expect(show1399.episode_groups.results.length).toBeGreaterThan(0);
 	});
 
-	it("(DETAILS + append: lists) should include lists", async () => {
-		const show = await tmdb.tv_series.details({ series_id: 1399, append_to_response: ["lists"] });
-		expect(show.lists).toBeDefined();
-		expect(Array.isArray(show.lists.results)).toBe(true);
+	it("(DETAILS + append: lists) should include lists", () => {
+		expect(show1399.lists).toBeDefined();
+		expect(Array.isArray(show1399.lists.results)).toBe(true);
 	});
 
-	it("(DETAILS + append: reviews) should include reviews", async () => {
-		const show = await tmdb.tv_series.details({ series_id: 1399, append_to_response: ["reviews"] });
-		expect(show.reviews).toBeDefined();
-		expect(Array.isArray(show.reviews.results)).toBe(true);
-		expect(show.reviews.results.length).toBeGreaterThan(0);
+	it("(DETAILS + append: reviews) should include reviews", () => {
+		expect(show1399.reviews).toBeDefined();
+		expect(Array.isArray(show1399.reviews.results)).toBe(true);
+		expect(show1399.reviews.results.length).toBeGreaterThan(0);
 	});
 
-	it("(DETAILS + append: screened_theatrically) should include screened_theatrically", async () => {
-		const show = await tmdb.tv_series.details({ series_id: 1399, append_to_response: ["screened_theatrically"] });
-		expect(show.screened_theatrically).toBeDefined();
-		expect(Array.isArray(show.screened_theatrically.results)).toBe(true);
+	it("(DETAILS + append: screened_theatrically) should include screened_theatrically", () => {
+		expect(show1399.screened_theatrically).toBeDefined();
+		expect(Array.isArray(show1399.screened_theatrically.results)).toBe(true);
 	});
 
-	it("(DETAILS + append: watch/providers) should include watch_providers", async () => {
-		const show = await tmdb.tv_series.details({ series_id: 1399, append_to_response: ["watch/providers"] });
-		expect(show["watch/providers"]).toBeDefined();
-		expect(show["watch/providers"].results).toBeDefined();
+	it("(DETAILS + append: watch/providers) should include watch_providers", () => {
+		expect(show1399["watch/providers"]).toBeDefined();
+		expect(show1399["watch/providers"].results).toBeDefined();
 	});
 });

--- a/packages/tmdb/src/tests/tv_series/tv_series.details.integration.test.ts
+++ b/packages/tmdb/src/tests/tv_series/tv_series.details.integration.test.ts
@@ -2,18 +2,48 @@ import { TMDB } from "../../tmdb";
 import { beforeAll, describe, expect, it } from "vitest";
 
 const token = process.env.TMDB_BEARER_TOKEN;
-if (!token) throw new Error("TMDB_BEARER_TOKEN is not set, please set it in your enviroment variables.");
+if (!token)
+	throw new Error("TMDB_BEARER_TOKEN is not set, please set it in your enviroment variables.");
 
 const tmdb = new TMDB(token, { language: "en-US", region: "US", timezone: "Europe/Rome" });
 
 describe("TV Series Details (integration)", () => {
-	let show1396: Awaited<ReturnType<typeof tmdb.tv_series.details<["aggregate_credits", "alternative_titles", "content_ratings"]>>>;
-	let show1399: Awaited<ReturnType<typeof tmdb.tv_series.details<["episode_groups", "lists", "reviews", "screened_theatrically", "watch/providers"]>>>;
+	let show1396: Awaited<
+		ReturnType<
+			typeof tmdb.tv_series.details<
+				["aggregate_credits", "alternative_titles", "content_ratings", "changes"]
+			>
+		>
+	>;
+	let show1399: Awaited<
+		ReturnType<
+			typeof tmdb.tv_series.details<
+				["episode_groups", "lists", "reviews", "screened_theatrically", "watch/providers"]
+			>
+		>
+	>;
 
 	beforeAll(async () => {
 		[show1396, show1399] = await Promise.all([
-			tmdb.tv_series.details({ series_id: 1396, append_to_response: ["aggregate_credits", "alternative_titles", "content_ratings"] }),
-			tmdb.tv_series.details({ series_id: 1399, append_to_response: ["episode_groups", "lists", "reviews", "screened_theatrically", "watch/providers"] }),
+			tmdb.tv_series.details({
+				series_id: 1396,
+				append_to_response: [
+					"aggregate_credits",
+					"alternative_titles",
+					"content_ratings",
+					"changes",
+				],
+			}),
+			tmdb.tv_series.details({
+				series_id: 1399,
+				append_to_response: [
+					"episode_groups",
+					"lists",
+					"reviews",
+					"screened_theatrically",
+					"watch/providers",
+				],
+			}),
 		]);
 	});
 
@@ -25,16 +55,24 @@ describe("TV Series Details (integration)", () => {
 	});
 
 	it("(DETAILS + appends: credits, external_ids) should include credits and external ids", async () => {
-		const show = await tmdb.tv_series.details({ series_id: 1396, append_to_response: ["credits", "external_ids"] });
+		const show = await tmdb.tv_series.details({
+			series_id: 1396,
+			append_to_response: ["credits", "external_ids"],
+		});
 		expect(show.external_ids).toBeDefined();
-		expect(typeof show.external_ids.imdb_id === "string" || show.external_ids.imdb_id === null).toBe(true);
+		expect(
+			typeof show.external_ids.imdb_id === "string" || show.external_ids.imdb_id === null,
+		).toBe(true);
 		expect(show.credits).toBeDefined();
 		expect(Array.isArray(show.credits.cast)).toBe(true);
 		expect(show.credits.cast.length).toBeGreaterThan(0);
 	});
 
 	it("(DETAILS + appends: images, videos) should include media collections", async () => {
-		const show = await tmdb.tv_series.details({ series_id: 1396, append_to_response: ["images", "videos"] });
+		const show = await tmdb.tv_series.details({
+			series_id: 1396,
+			append_to_response: ["images", "videos"],
+		});
 		expect(show.images).toBeDefined();
 		expect(Array.isArray(show.images.posters)).toBe(true);
 		expect(show.videos).toBeDefined();
@@ -63,6 +101,12 @@ describe("TV Series Details (integration)", () => {
 		expect(show1396.alternative_titles).toBeDefined();
 		expect(Array.isArray(show1396.alternative_titles.results)).toBe(true);
 		expect(show1396.alternative_titles.results.length).toBeGreaterThan(0);
+	});
+
+	it("(DETAILS + append: changes) should include changes", () => {
+		expect(show1396.changes).toBeDefined();
+		expect(Array.isArray(show1396.changes.changes)).toBe(true);
+		expect(show1396.changes.changes.length).toBeGreaterThan(0);
 	});
 
 	it("(DETAILS + append: content_ratings) should include content_ratings", () => {

--- a/packages/tmdb/src/types/tv-series.ts
+++ b/packages/tmdb/src/types/tv-series.ts
@@ -25,6 +25,7 @@ import { NetworkItem } from "./networks";
 import { VideoItem } from "./common";
 import { Language, LanguageISO6391, Timezone } from "./config";
 import { TVSeriesResultItem } from "./search";
+import { MediaWatchProviders } from "./common/media";
 import { Prettify } from "./utility";
 
 // MARK: Details
@@ -144,27 +145,43 @@ export type TVSeasonItem = {
  * These allow fetching additional related data in a single API request.
  */
 export type TVAppendToResponseNamespace =
+	| "aggregate_credits"
+	| "alternative_titles"
+	| "content_ratings"
 	| "credits"
+	| "episode_groups"
 	| "external_ids"
 	| "images"
 	| "keywords"
+	| "lists"
 	| "recommendations"
+	| "reviews"
+	| "screened_theatrically"
 	| "similar"
 	| "translations"
-	| "videos";
+	| "videos"
+	| "watch/providers";
 
 /**
  * Maps append-to-response keys to their corresponding response types.
  */
 export type TVAppendableMap = {
+	aggregate_credits: TVAggregateCredits;
+	alternative_titles: TVAlternativeTitles;
+	content_ratings: TVContentRatings;
 	credits: TVCredits;
+	episode_groups: TVEpisodeGroups;
 	external_ids: TVExternalIDs;
 	images: TVImages;
 	keywords: TVKeywords;
+	lists: TVSeriesLists;
 	recommendations: TVRecommendations;
+	reviews: TVReviews;
+	screened_theatrically: TVScreenedTheatrically;
 	similar: TVSimilar;
 	translations: TVTranslations;
 	videos: TVVideos;
+	"watch/providers": MediaWatchProviders;
 };
 
 /**

--- a/packages/tmdb/src/types/tv-series.ts
+++ b/packages/tmdb/src/types/tv-series.ts
@@ -147,6 +147,7 @@ export type TVSeasonItem = {
 export type TVAppendToResponseNamespace =
 	| "aggregate_credits"
 	| "alternative_titles"
+	| "changes"
 	| "content_ratings"
 	| "credits"
 	| "episode_groups"
@@ -168,6 +169,7 @@ export type TVAppendToResponseNamespace =
 export type TVAppendableMap = {
 	aggregate_credits: TVAggregateCredits;
 	alternative_titles: TVAlternativeTitles;
+	changes: TVSeriesChanges;
 	content_ratings: TVContentRatings;
 	credits: TVCredits;
 	episode_groups: TVEpisodeGroups;
@@ -188,9 +190,10 @@ export type TVAppendableMap = {
  * TV show details with additional appended data based on the requested namespaces.
  * @template T - Array of append-to-response namespace keys to include
  */
-export type TVDetailsWithAppends<T extends readonly TVAppendToResponseNamespace[]> = TVSeriesDetails & {
-	[K in T[number]]: TVAppendableMap[K];
-};
+export type TVDetailsWithAppends<T extends readonly TVAppendToResponseNamespace[]> =
+	TVSeriesDetails & {
+		[K in T[number]]: TVAppendableMap[K];
+	};
 
 // MARK: Aggreate Credits
 
@@ -501,7 +504,9 @@ export type TVSeriesListParams = Prettify<WithLanguagePage & { timezone?: Timezo
 /**
  * Parameters for fetching TV show details with optional additional data appended.
  */
-export type TVDetailsParams = Prettify<TVBaseParam & { append_to_response?: TVAppendToResponseNamespace[] } & WithParams<"language">>;
+export type TVDetailsParams = Prettify<
+	TVBaseParam & { append_to_response?: TVAppendToResponseNamespace[] } & WithParams<"language">
+>;
 
 /**
  * Parameters for fetching aggregate credits for a TV show (cast and crew across all seasons).


### PR DESCRIPTION
## Summary

- Adds 8 missing values to `TVAppendToResponseNamespace`: `aggregate_credits`, `alternative_titles`, `content_ratings`, `episode_groups`, `lists`, `reviews`, `screened_theatrically`, `watch/providers`
- Updates `TVAppendableMap` with corresponding return types for each new key
- Imports `MediaWatchProviders` in `tv-series.ts`

Note: `watch_providers` is not valid — TMDB returns this under the key `watch/providers` (matching the `/watch/providers` sub-path). `changes` is also excluded as TMDB does not support it via `append_to_response`.

## Test Plan

- [x] Integration tests added for each new `append_to_response` value in `tv_series.details.integration.test.ts`
- [x] All 8 values verified against live TMDB API — each returns real data
- [x] 680 unit tests pass

Closes #118