### PR TITLE
fix(collections): correct CollectionItem to use title/original_title

### DIFF
--- a/apps/docs/content/docs/types/collections.mdx
+++ b/apps/docs/content/docs/types/collections.mdx
@@ -13,6 +13,10 @@ import { TypeTable } from "fumadocs-ui/components/type-table";
 
 ## `CollectionItem`
 
+<Callout type="warn">
+  **Breaking change in v1.22.2** — fields were previously typed as `name` and `original_name` (matching the incorrect TMDB API docs). The actual API returns `title` and `original_title`. Rename any access of `.name` → `.title` and `.original_name` → `.original_title` on `CollectionItem` values.
+</Callout>
+
 <AutoTypeTable path="collections.ts" name="CollectionItem" />
 
 ## `CollectionImages`

--- a/packages/tmdb/src/tests/collections/collections.integration.test.ts
+++ b/packages/tmdb/src/tests/collections/collections.integration.test.ts
@@ -16,6 +16,17 @@ describe("Collections API", () => {
 		expect(Array.isArray(collection.parts)).toBe(true);
 	});
 
+	it("(DETAILS) parts items should have title and original_title, not name/original_name", async () => {
+		// Harry Potter Collection (id: 1241) — different from the Star Wars fixture used elsewhere
+		const collection = await tmdb.collections.details({ collection_id: 1241, language: "en" });
+		expect(collection.parts.length).toBeGreaterThan(0);
+		const part = collection.parts[0];
+		expect(part.title).toBeDefined();
+		expect(part.original_title).toBeDefined();
+		expect((part as Record<string, unknown>).name).toBeUndefined();
+		expect((part as Record<string, unknown>).original_name).toBeUndefined();
+	});
+
 	it("(DETAILS) should fetch collection details with language", async () => {
 		const collection = await tmdb.collections.details({ collection_id: 10, language: "en" });
 		expect(collection.id).toBe(10);

--- a/packages/tmdb/src/tests/collections/collections.test.ts
+++ b/packages/tmdb/src/tests/collections/collections.test.ts
@@ -43,6 +43,31 @@ describe("CollectionsAPI", () => {
 			const result = await collectionsAPI.details({ collection_id: 10 });
 			expect(result).toEqual(fakeResponse);
 		});
+
+		it("should surface title and original_title (not name/original_name) on CollectionItem parts", async () => {
+			const fakePart = {
+				id: 1,
+				title: "Star Wars: Episode IV - A New Hope",
+				original_title: "Star Wars",
+				media_type: "movie",
+				overview: "",
+				poster_path: null,
+				backdrop_path: null,
+				adult: false,
+				original_language: "en",
+				genre_ids: [],
+				popularity: 1,
+				release_date: "1977-05-25",
+				video: false,
+				vote_average: 8.6,
+				vote_count: 10000,
+			};
+			const fakeResponse = { id: 10, name: "Star Wars Collection", parts: [fakePart] };
+			(clientMock.request as ReturnType<typeof vi.fn>).mockResolvedValue(fakeResponse);
+			const result = await collectionsAPI.details({ collection_id: 10 });
+			expect(result.parts[0].title).toBe("Star Wars: Episode IV - A New Hope");
+			expect(result.parts[0].original_title).toBe("Star Wars");
+		});
 	});
 
 	describe("images", () => {

--- a/packages/tmdb/src/types/collections.ts
+++ b/packages/tmdb/src/types/collections.ts
@@ -28,17 +28,13 @@ export type Collection = {
 
 /**
  * Represents a single media item within a collection.
- * Extends {@link MovieResultItem} by replacing `title` and `original_title`
- * with their localization-agnostic equivalents, and adding a `media_type` discriminator.
- * Hopefully both tv and movies use name and original name instead of title.
+ * Extends {@link MovieResultItem} with a `media_type` discriminator.
+ * Despite what the TMDB API docs show, the actual API response uses `title` and
+ * `original_title` (not `name`/`original_name`) for items in the `parts` array.
  */
-export type CollectionItem = Omit<MovieResultItem, "title" | "original_title"> & {
+export type CollectionItem = MovieResultItem & {
 	/** The type of media (e.g. `"movie"` or `"tv"`), used as a discriminator */
 	media_type: MediaType;
-	/** Display name of the media item */
-	name: string;
-	/** Name of the media item in its original language */
-	original_name: string;
 };
 
 /**


### PR DESCRIPTION
## Summary

- `CollectionItem` was typed with `name` and `original_name` based on misleading TMDB API docs; the actual API has always returned `title` and `original_title` for items in the `parts` array
- Fixed the type to extend `MovieResultItem & { media_type }` directly, removing the incorrect `Omit` + field replacement
- Added a `<Callout>` migration note in the `CollectionItem` type docs

## Migration

Rename any access on `CollectionItem` values:
- `.name` → `.title`
- `.original_name` → `.original_title`

## Test Plan

- [x] Unit test: verifies `parts[0].title` and `parts[0].original_title` surface correctly from mock response
- [x] Integration test: hits real TMDB API with collection `1241` (Harry Potter — independent of existing Star Wars fixture), asserts `title`/`original_title` defined and `name`/`original_name` undefined
- [x] All 681 unit tests pass

Closes #119

🤖 Generated with [Claude Code](https://claude.com/claude-code)