### PR TITLE
fix(types): export MovieReleaseType and rename from ReleaseType

### DIFF
--- a/apps/docs/content/docs/api-reference/movies/release-dates.mdx
+++ b/apps/docs/content/docs/api-reference/movies/release-dates.mdx
@@ -21,7 +21,7 @@ async release_dates(params: MovieReleaseDatesParams): Promise<MovieReleaseDates>
 
 [`MovieReleaseDates`](/docs/types/movies#moviereleasedates)
 
-Release types are represented by the [`ReleaseType`](/docs/types/enums#releasetype) enum.
+Release types are represented by the [`MovieReleaseType`](/docs/types/enums#moviereleasetype) enum.
 
 ## Example
 

--- a/apps/docs/content/docs/types/discover.mdx
+++ b/apps/docs/content/docs/types/discover.mdx
@@ -40,7 +40,7 @@ Parameters for [`discover.movie()`](/docs/api-reference/discover/movie).
 		without_keywords: { type: "DiscoverFilterExpression<number>", description: "Exclude keyword IDs." },
 		with_companies: { type: "DiscoverFilterExpression<number>", description: "Filter by production company IDs." },
 		without_companies: { type: "DiscoverFilterExpression<number>", description: "Exclude production company IDs." },
-		with_release_type: { type: "DiscoverFilterExpression<ReleaseType>", description: "Filter by TMDB release types." },
+		with_release_type: { type: "DiscoverFilterExpression<MovieReleaseType>", description: "Filter by TMDB release types." },
 		"with_runtime.gte": { type: "number", description: "Minimum runtime in minutes." },
 		"with_runtime.lte": { type: "number", description: "Maximum runtime in minutes." },
 		"vote_average.gte": { type: "number", description: "Minimum average vote." },
@@ -229,5 +229,5 @@ A simplified TV series object returned by [`discover.tv()`](/docs/api-reference/
 
 - [`MovieResultItem`](/docs/types/search#movieresultitem)
 - [`WatchMonetizationType`](/docs/types/common#watchmonetizationtype)
-- [`ReleaseType`](/docs/types/enums#releasetype)
+- [`MovieReleaseType`](/docs/types/enums#moviereleasetype)
 - [`PaginatedResponse`](/docs/types/common#paginatedresponset)

--- a/apps/docs/content/docs/types/enums.mdx
+++ b/apps/docs/content/docs/types/enums.mdx
@@ -5,10 +5,10 @@ description: Enumerated values used across TMDB API responses.
 
 Enumerated constants used in TMDB API responses to represent typed numeric values.
 
-## `ReleaseType`
+## `MovieReleaseType`
 
 Represents the type of a movie release as defined by TMDB.
-Used in [`MovieReleaseDate.type`](/docs/types/movies#moviereleasedate).
+Used in [`MovieReleaseDate.type`](/docs/types/movies#moviereleasedate) and [`DiscoverMovieParams.with_release_type`](/docs/types/discover#discovermovie).
 
 | Value | Name                | Description                                                                  |
 | ----- | ------------------- | ---------------------------------------------------------------------------- |
@@ -20,9 +20,9 @@ Used in [`MovieReleaseDate.type`](/docs/types/movies#moviereleasedate).
 | `6`   | `TV`                | Television broadcast premiere.                                               |
 
 ```ts
-import { ReleaseType } from "@lorenzopant/tmdb";
+import { MovieReleaseType } from "@lorenzopant/tmdb";
 
-if (releaseDate.type === ReleaseType.Theatrical) {
+if (releaseDate.type === MovieReleaseType.Theatrical) {
 	console.log("Wide theatrical release");
 }
 ```

--- a/apps/docs/content/docs/types/enums.mdx
+++ b/apps/docs/content/docs/types/enums.mdx
@@ -8,7 +8,7 @@ Enumerated constants used in TMDB API responses to represent typed numeric value
 ## `MovieReleaseType`
 
 Represents the type of a movie release as defined by TMDB.
-Used in [`MovieReleaseDate.type`](/docs/types/movies#moviereleasedate) and [`DiscoverMovieParams.with_release_type`](/docs/types/discover#discovermovie).
+Used in [`MovieReleaseDate.type`](/docs/types/movies#moviereleasedate) and [`DiscoverMovieParams.with_release_type`](/docs/types/discover#discovermovieparams).
 
 | Value | Name                | Description                                                                  |
 | ----- | ------------------- | ---------------------------------------------------------------------------- |

--- a/apps/docs/content/docs/types/movies.mdx
+++ b/apps/docs/content/docs/types/movies.mdx
@@ -187,13 +187,13 @@ See [`MovieResultItem`](/docs/types/search#movieresultitem).
 		certification: { type: "string", description: 'Age certification/rating (e.g., "PG-13", "R").' },
 		iso_639_1: { type: "string", description: "ISO 639-1 language code." },
 		release_date: { type: "string", description: "Release date and time in ISO 8601 format." },
-		type: { type: "ReleaseType | number", description: "Type of release. See ReleaseType enum." },
+		type: { type: "MovieReleaseType | number", description: "Type of release. See MovieReleaseType enum." },
 		note: { type: "string", description: "Additional notes about this release." },
 		descriptors: { type: "unknown[]", description: "Content descriptors (currently unused by TMDB)." },
 	}}
 />
 
-See [`ReleaseType`](/docs/types/enums#releasetype).
+See [`MovieReleaseType`](/docs/types/enums#moviereleasetype).
 
 ---
 

--- a/packages/tmdb/src/types/discover.ts
+++ b/packages/tmdb/src/types/discover.ts
@@ -1,6 +1,6 @@
 import { WatchMonetizationType } from "./common";
 import { CountryISO3166_1, Language, LanguageISO6391 } from "./config";
-import { ReleaseType } from "./enums";
+import { MovieReleaseType } from "./enums";
 import { LiteralUnion, Prettify } from "./utility";
 
 /**
@@ -139,7 +139,7 @@ export type DiscoverMovieParams = Prettify<
 		with_cast?: DiscoverFilterExpression<number>;
 		with_crew?: DiscoverFilterExpression<number>;
 		with_people?: DiscoverFilterExpression<number>;
-		with_release_type?: DiscoverFilterExpression<ReleaseType>;
+		with_release_type?: DiscoverFilterExpression<MovieReleaseType>;
 		"with_runtime.gte"?: number;
 		"with_runtime.lte"?: number;
 		year?: number;

--- a/packages/tmdb/src/types/enums.ts
+++ b/packages/tmdb/src/types/enums.ts
@@ -1,4 +1,4 @@
-export enum ReleaseType {
+export enum MovieReleaseType {
 	Premiere = 1,
 	TheatricalLimited = 2,
 	Theatrical = 3,

--- a/packages/tmdb/src/types/index.ts
+++ b/packages/tmdb/src/types/index.ts
@@ -1,4 +1,5 @@
 export * from "./common";
+export * from "./enums";
 export * from "./config";
 export * from "./account";
 export * from "./authentication";

--- a/packages/tmdb/src/types/movies.ts
+++ b/packages/tmdb/src/types/movies.ts
@@ -22,7 +22,7 @@ import {
 	WithParams,
 } from "./common";
 import { CountryISO3166_1, Language, LanguageISO6391 } from "./config";
-import { ReleaseType } from "./enums";
+import { MovieReleaseType } from "./enums";
 import { MovieResultItem } from "./search";
 import { Prettify } from "./utility";
 
@@ -245,7 +245,7 @@ export type MovieReleaseDate = {
 	/** Release date and time in ISO 8601 format */
 	release_date: string;
 	/** Type of release (1=Premiere, 2=Theatrical (limited), 3=Theatrical, 4=Digital, 5=Physical, 6=TV) */
-	type: ReleaseType | number;
+	type: MovieReleaseType | number;
 	/** Additional notes about this release */
 	note: string;
 	/** Content descriptors (currently unused by TMDB) */


### PR DESCRIPTION
## Summary

- `ReleaseType` was never re-exported from `packages/tmdb/src/types/index.ts`, making it inaccessible to consumers
- Renamed to `MovieReleaseType` — enum is scoped exclusively to movie release dates and movie discover filters (TV has no equivalent)
- Updated all docs references

## Test plan

- [ ] `import { MovieReleaseType } from "@lorenzopant/tmdb"` resolves correctly
- [x] `MovieReleaseDate.type` and `DiscoverMovieParams.with_release_type` typed correctly
- [x] Docs links resolve to `#moviereleasetype` anchor

Closes #120