### PR TITLE
fix(types): add vote_average to TVSeasonItem

### DIFF
--- a/packages/tmdb/src/tests/tv_series/tv_series.details.integration.test.ts
+++ b/packages/tmdb/src/tests/tv_series/tv_series.details.integration.test.ts
@@ -12,6 +12,8 @@ describe("TV Series Details (integration)", () => {
 		expect(show.id).toBe(1396);
 		expect(typeof show.name).toBe("string");
 		expect(show.number_of_seasons).toBeGreaterThan(0);
+		expect(Array.isArray(show.seasons)).toBe(true);
+		expect(typeof show.seasons![0].vote_average).toBe("number");
 	});
 
 	it("(DETAILS + appends: credits, external_ids) should include credits and external ids", async () => {

--- a/packages/tmdb/src/types/tv-series.ts
+++ b/packages/tmdb/src/types/tv-series.ts
@@ -137,6 +137,8 @@ export type TVSeasonItem = {
 	poster_path?: string;
 	/** The season number within the TV show */
 	season_number: number;
+	/** The average vote score for the season */
+	vote_average: number;
 };
 
 /**


### PR DESCRIPTION
## Summary

- `TVSeasonItem` was missing `vote_average` field despite TMDB API returning it

## Test plan

- [x] Verify `TVSeasonItem` type now includes `vote_average: number`
- [x] Check `AutoTypeTable` in docs renders the new field

Closes #121