### PR TITLE
feat(enums): replace enums with const objects and label maps

### DIFF
--- a/apps/docs/content/docs/types/discover.mdx
+++ b/apps/docs/content/docs/types/discover.mdx
@@ -162,43 +162,6 @@ type DiscoverTVSortBy =
 
 ---
 
-## Discover Enums
-
-### `DiscoverTVStatus`
-
-Numeric values accepted by TMDB's `with_status` TV discover filter.
-
-<TypeTable
-	type={{
-		ReturningSeries: { type: "0", description: "Returning series status." },
-		Planned: { type: "1", description: "Planned status." },
-		InProduction: { type: "2", description: "In production status." },
-		Ended: { type: "3", description: "Ended status." },
-		Canceled: { type: "4", description: "Canceled status." },
-		Pilot: { type: "5", description: "Pilot status." },
-	}}
-/>
-
----
-
-### `DiscoverTVType`
-
-Numeric values accepted by TMDB's `with_type` TV discover filter.
-
-<TypeTable
-	type={{
-		Documentary: { type: "0", description: "Documentary type." },
-		News: { type: "1", description: "News type." },
-		Miniseries: { type: "2", description: "Miniseries type." },
-		Reality: { type: "3", description: "Reality type." },
-		Scripted: { type: "4", description: "Scripted type." },
-		TalkShow: { type: "5", description: "Talk show type." },
-		Video: { type: "6", description: "Video type." },
-	}}
-/>
-
----
-
 ## Result Items
 
 ### `DiscoverTVResultItem`
@@ -230,4 +193,6 @@ A simplified TV series object returned by [`discover.tv()`](/docs/api-reference/
 - [`MovieResultItem`](/docs/types/search#movieresultitem)
 - [`WatchMonetizationType`](/docs/types/common#watchmonetizationtype)
 - [`MovieReleaseType`](/docs/types/enums#moviereleasetype)
+- [`DiscoverTVStatus`](/docs/types/enums#discovertvstatus)
+- [`DiscoverTVType`](/docs/types/enums#discovertvtype)
 - [`PaginatedResponse`](/docs/types/common#paginatedresponset)

--- a/apps/docs/content/docs/types/enums.mdx
+++ b/apps/docs/content/docs/types/enums.mdx
@@ -5,6 +5,8 @@ description: Enumerated values used across TMDB API responses.
 
 Enumerated constants used in TMDB API responses to represent typed numeric values.
 
+These are exported as `const` objects (not TypeScript `enum`s). Named access works the same way (`MovieReleaseType.Theatrical`), and each has a companion `*Label` map for numeric → human-readable string lookups.
+
 ## `MovieReleaseType`
 
 Represents the type of a movie release as defined by TMDB.
@@ -20,9 +22,91 @@ Used in [`MovieReleaseDate.type`](/docs/types/movies#moviereleasedate) and [`Dis
 | `6`   | `TV`                | Television broadcast premiere.                                               |
 
 ```ts
-import { MovieReleaseType } from "@lorenzopant/tmdb";
+import { MovieReleaseType, MovieReleaseTypeLabel } from "@lorenzopant/tmdb";
 
 if (releaseDate.type === MovieReleaseType.Theatrical) {
 	console.log("Wide theatrical release");
 }
+
+// Human-readable label from a numeric value
+MovieReleaseTypeLabel[releaseDate.type]; // e.g. "Theatrical"
+```
+
+---
+
+## `DiscoverTVStatus`
+
+Numeric status values accepted by TMDB's `with_status` TV discover filter.
+Used in [`DiscoverTVParams.with_status`](/docs/types/discover#discovertvparams).
+
+| Value | Name              | Description          |
+| ----- | ----------------- | -------------------- |
+| `0`   | `ReturningSeries` | Currently airing.    |
+| `1`   | `Planned`         | Not yet in production. |
+| `2`   | `InProduction`    | Currently in production. |
+| `3`   | `Ended`           | Series has ended.    |
+| `4`   | `Canceled`        | Series was canceled. |
+| `5`   | `Pilot`           | Pilot stage only.    |
+
+```ts
+import { DiscoverTVStatus, DiscoverTVStatusLabel } from "@lorenzopant/tmdb";
+
+tmdb.discover.tv({ with_status: DiscoverTVStatus.ReturningSeries });
+
+// Human-readable label from a numeric value
+DiscoverTVStatusLabel[series.status]; // e.g. "Returning Series"
+```
+
+---
+
+## `DiscoverTVType`
+
+Numeric type values accepted by TMDB's `with_type` TV discover filter.
+Used in [`DiscoverTVParams.with_type`](/docs/types/discover#discovertvparams).
+
+| Value | Name          | Description      |
+| ----- | ------------- | ---------------- |
+| `0`   | `Documentary` | Documentary.     |
+| `1`   | `News`        | News program.    |
+| `2`   | `Miniseries`  | Miniseries.      |
+| `3`   | `Reality`     | Reality show.    |
+| `4`   | `Scripted`    | Scripted series. |
+| `5`   | `TalkShow`    | Talk show.       |
+| `6`   | `Video`       | Video.           |
+
+```ts
+import { DiscoverTVType, DiscoverTVTypeLabel } from "@lorenzopant/tmdb";
+
+tmdb.discover.tv({ with_type: DiscoverTVType.Scripted });
+
+// Human-readable label from a numeric value
+DiscoverTVTypeLabel[series.type]; // e.g. "Scripted"
+```
+
+---
+
+## `TVEpisodeGroupType`
+
+Identifies the grouping strategy used by a TV episode group.
+Used in [`TVEpisodeGroupDetails.type`](/docs/types/tv-episode-groups#tvepisodegroupdetails).
+
+| Value | Name              | Description                        |
+| ----- | ----------------- | ---------------------------------- |
+| `1`   | `OriginalAirDate` | Grouped by original air date.      |
+| `2`   | `Absolute`        | Absolute episode ordering.         |
+| `3`   | `Dvd`             | DVD release ordering.              |
+| `4`   | `Digital`         | Digital release ordering.          |
+| `5`   | `StoryArc`        | Grouped by story arc.              |
+| `6`   | `Production`      | Production ordering.               |
+| `7`   | `TV`              | TV broadcast ordering.             |
+
+```ts
+import { TVEpisodeGroupType, TVEpisodeGroupTypeLabel } from "@lorenzopant/tmdb";
+
+if (group.type === TVEpisodeGroupType.OriginalAirDate) {
+	console.log("Ordered by air date");
+}
+
+// Human-readable label from a numeric value
+TVEpisodeGroupTypeLabel[group.type]; // e.g. "Original Air Date"
 ```

--- a/apps/docs/content/docs/types/tv-episode-groups.mdx
+++ b/apps/docs/content/docs/types/tv-episode-groups.mdx
@@ -11,17 +11,7 @@ Types related to the [TV Episode Groups](/docs/api-reference/tv-episode-groups) 
 
 ## `TVEpisodeGroupType`
 
-```ts
-enum TVEpisodeGroupType {
-	OriginalAirDate = 1,
-	Absolute = 2,
-	Dvd = 3,
-	Digital = 4,
-	StoryArc = 5,
-	Production = 6,
-	TV = 7,
-}
-```
+See [`TVEpisodeGroupType`](/docs/types/enums#tvepisodegrouptype) in the Enums reference.
 
 ## `TVEpisodeGroupDetailsItem`
 

--- a/packages/tmdb/src/types/discover.ts
+++ b/packages/tmdb/src/types/discover.ts
@@ -1,6 +1,6 @@
 import { WatchMonetizationType } from "./common";
 import { CountryISO3166_1, Language, LanguageISO6391 } from "./config";
-import { MovieReleaseType } from "./enums";
+import { DiscoverTVStatus, DiscoverTVType, MovieReleaseType } from "./enums";
 import { LiteralUnion, Prettify } from "./utility";
 
 /**
@@ -40,33 +40,6 @@ export type DiscoverTVSortBy =
 	| "vote_average.desc"
 	| "vote_count.asc"
 	| "vote_count.desc";
-
-/**
- * TV status values accepted by TMDB discover filters.
- * @reference https://developer.themoviedb.org/reference/discover-tv
- */
-export enum DiscoverTVStatus {
-	ReturningSeries = 0,
-	Planned = 1,
-	InProduction = 2,
-	Ended = 3,
-	Canceled = 4,
-	Pilot = 5,
-}
-
-/**
- * TV type values accepted by TMDB discover filters.
- * @reference https://developer.themoviedb.org/reference/discover-tv
- */
-export enum DiscoverTVType {
-	Documentary = 0,
-	News = 1,
-	Miniseries = 2,
-	Reality = 3,
-	Scripted = 4,
-	TalkShow = 5,
-	Video = 6,
-}
 
 /**
  * A TV result item as returned by discover endpoints.

--- a/packages/tmdb/src/types/enums.ts
+++ b/packages/tmdb/src/types/enums.ts
@@ -1,8 +1,94 @@
-export enum MovieReleaseType {
-	Premiere = 1,
-	TheatricalLimited = 2,
-	Theatrical = 3,
-	Digital = 4,
-	Physical = 5,
-	TV = 6,
-}
+export const MovieReleaseType = {
+	Premiere: 1,
+	TheatricalLimited: 2,
+	Theatrical: 3,
+	Digital: 4,
+	Physical: 5,
+	TV: 6,
+} as const;
+
+export type MovieReleaseType = (typeof MovieReleaseType)[keyof typeof MovieReleaseType];
+
+export const MovieReleaseTypeLabel: Record<MovieReleaseType, string> = {
+	1: "Premiere",
+	2: "Theatrical (Limited)",
+	3: "Theatrical",
+	4: "Digital",
+	5: "Physical",
+	6: "TV",
+};
+
+/**
+ * TV status values accepted by TMDB discover filters.
+ * @reference https://developer.themoviedb.org/reference/discover-tv
+ */
+export const DiscoverTVStatus = {
+	ReturningSeries: 0,
+	Planned: 1,
+	InProduction: 2,
+	Ended: 3,
+	Canceled: 4,
+	Pilot: 5,
+} as const;
+
+export type DiscoverTVStatus = (typeof DiscoverTVStatus)[keyof typeof DiscoverTVStatus];
+
+export const DiscoverTVStatusLabel: Record<DiscoverTVStatus, string> = {
+	0: "Returning Series",
+	1: "Planned",
+	2: "In Production",
+	3: "Ended",
+	4: "Canceled",
+	5: "Pilot",
+};
+
+/**
+ * TV type values accepted by TMDB discover filters.
+ * @reference https://developer.themoviedb.org/reference/discover-tv
+ */
+export const DiscoverTVType = {
+	Documentary: 0,
+	News: 1,
+	Miniseries: 2,
+	Reality: 3,
+	Scripted: 4,
+	TalkShow: 5,
+	Video: 6,
+} as const;
+
+export type DiscoverTVType = (typeof DiscoverTVType)[keyof typeof DiscoverTVType];
+
+export const DiscoverTVTypeLabel: Record<DiscoverTVType, string> = {
+	0: "Documentary",
+	1: "News",
+	2: "Miniseries",
+	3: "Reality",
+	4: "Scripted",
+	5: "Talk Show",
+	6: "Video",
+};
+
+/**
+ * Supported episode group type identifiers.
+ */
+export const TVEpisodeGroupType = {
+	OriginalAirDate: 1,
+	Absolute: 2,
+	Dvd: 3,
+	Digital: 4,
+	StoryArc: 5,
+	Production: 6,
+	TV: 7,
+} as const;
+
+export type TVEpisodeGroupType = (typeof TVEpisodeGroupType)[keyof typeof TVEpisodeGroupType];
+
+export const TVEpisodeGroupTypeLabel: Record<TVEpisodeGroupType, string> = {
+	1: "Original Air Date",
+	2: "Absolute",
+	3: "DVD",
+	4: "Digital",
+	5: "Story Arc",
+	6: "Production",
+	7: "TV",
+};

--- a/packages/tmdb/src/types/tv-episode-groups.ts
+++ b/packages/tmdb/src/types/tv-episode-groups.ts
@@ -1,3 +1,4 @@
+import { TVEpisodeGroupType } from "./enums";
 import { NetworkItem } from "./networks";
 import { TVEpisode } from "./tv-episodes";
 
@@ -48,19 +49,6 @@ export type TVEpisodeGroupEpisode = Omit<TVEpisode, "guest_stars" | "runtime"> &
 	/** Path to the episode still image, if available */
 	still_path?: string;
 };
-
-/**
- * Supported episode group type identifiers.
- */
-export enum TVEpisodeGroupType {
-	OriginalAirDate = 1,
-	Absolute = 2,
-	Dvd = 3,
-	Digital = 4,
-	StoryArc = 5,
-	Production = 6,
-	TV = 7,
-}
 
 export type TVEpisodeGroupParams = {
 	/** Episode group identifier */


### PR DESCRIPTION
## Summary

- Replaces all 4 TypeScript `enum`s with `as const` objects + type aliases — eliminates numeric enum pitfalls (reverse mapping bloat, structural typing issues, tree-shaking)
- Adds `*Label` maps (`MovieReleaseTypeLabel`, `DiscoverTVStatusLabel`, `DiscoverTVTypeLabel`, `TVEpisodeGroupTypeLabel`) for human-readable reverse lookup
- Consolidates all enum declarations into `types/enums.ts`

Closes #122

## Breaking changes

None for named access (e.g. `TVEpisodeGroupType.OriginalAirDate` still works). Reverse lookup via `TVEpisodeGroupType[1]` no longer works — use the new `TVEpisodeGroupTypeLabel[1]` instead.

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] Named access `TVEpisodeGroupType.OriginalAirDate === 1` still holds
- [x] Label maps return correct strings e.g. `TVEpisodeGroupTypeLabel[1] === "Original Air Date"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)