### PR TITLE
fix(docs/mcp): return 405 for GET/DELETE on stateless MCP endpoint

### DIFF
--- a/apps/docs/app/mcp/route.ts
+++ b/apps/docs/app/mcp/route.ts
@@ -95,16 +95,43 @@ async function handleRequest(request: Request): Promise<Response> {
 	}
 }
 
-export async function GET(request: Request): Promise<Response> {
-	return handleRequest(request);
+// Stateless MCP endpoint: only POST (JSON-RPC request/response) is supported.
+// GET (server-to-client SSE stream) and DELETE (session teardown) have no
+// meaning without sessions, so reject them *before* constructing the MCP
+// server to avoid the per-request cost. Returning 405 instead of 200 also tells
+// spec-compliant clients that no SSE stream is offered, so they fall back to
+// POST-only instead of looping reconnects on a stream that never stays open.
+function methodNotAllowed(): Response {
+	return new Response(
+		JSON.stringify({
+			jsonrpc: "2.0",
+			error: {
+				code: -32000,
+				message: "Method not allowed: this MCP endpoint is stateless. Use POST.",
+			},
+			id: null,
+		}),
+		{
+			status: 405,
+			headers: {
+				"Content-Type": "application/json",
+				Allow: "POST, OPTIONS",
+				"Access-Control-Allow-Origin": "*",
+			},
+		},
+	);
+}
+
+export async function GET(): Promise<Response> {
+	return methodNotAllowed();
 }
 
 export async function POST(request: Request): Promise<Response> {
 	return handleRequest(request);
 }
 
-export async function DELETE(request: Request): Promise<Response> {
-	return handleRequest(request);
+export async function DELETE(): Promise<Response> {
+	return methodNotAllowed();
 }
 
 export async function OPTIONS(): Promise<Response> {
@@ -112,7 +139,7 @@ export async function OPTIONS(): Promise<Response> {
 		status: 204,
 		headers: {
 			"Access-Control-Allow-Origin": "*",
-			"Access-Control-Allow-Methods": "GET, POST, DELETE, OPTIONS",
+			"Access-Control-Allow-Methods": "POST, OPTIONS",
 			"Access-Control-Allow-Headers": "Content-Type, Accept, Mcp-Session-Id, MCP-Protocol-Version",
 		},
 	});


### PR DESCRIPTION
## Problem

The docs MCP endpoint (`apps/docs/app/mcp/route.ts`) was driving the Vercel project to **100% usage** — `function invocations` and `edge requests` in particular.

Runtime logs showed `/mcp` accounting for **~99% of all function traffic** (thousands of hits vs. ~15 for every docs page combined), and every one was:

- **GET** (never POST), all **200**, all `cache=MISS`, a steady **~1 req/sec** loop from a single deployment. No errors.

### Root cause

The endpoint is **stateless** (`sessionIdGenerator: undefined`, `enableJsonResponse: true`), so it only meaningfully supports **POST** (JSON-RPC request/response). But every HTTP method — GET, POST, DELETE — was routed through the MCP server and answered **200**.

In MCP Streamable HTTP, **GET opens a server→client SSE notification stream**. A stateless server has no session to hold that stream open, so the connection drops immediately; the client's SSE layer then auto-reconnects → GET → 200 → drop → reconnect… = the sustained ~1/sec GET loop. The wrong `200` (instead of `405`) is what fed the loop.

## Fix

Reject **GET** and **DELETE** with **405** (`Allow: POST, OPTIONS`) **before** constructing the `McpServer`/transport. Per the Streamable HTTP spec, `405` signals no SSE stream is offered, so spec-compliant clients stop reconnecting and fall back to POST-only — exactly how a stateless server is meant to run. POST tool calls are untouched. CORS `Access-Control-Allow-Methods` narrowed to `POST, OPTIONS` to match.

This attacks the root cause: well-behaved clients stop the loop → invocations + edge requests drop at the source. (A follow-up WAF deny + persistent IP-block rule can guarantee the billing cut against clients that ignore 405, since a denied request only escapes edge-request billing when blocked *before* firewall processing.)

## Why stateless, not stateful

This is a pure request/response service (two synchronous tools over static docs). Statefulness only buys a server-push SSE stream this service never uses — and on serverless it's unreliable (no cross-invocation memory / session affinity) and *more* expensive (a held-open stream bills function duration the whole time). Stateless + 405 is the correct pattern.

## Verification

Local `next dev` smoke test:

| Request | Result |
|---|---|
| `GET /mcp` | **405** + `Allow: POST, OPTIONS` |
| `DELETE /mcp` | **405** |
| `OPTIONS /mcp` | **204**, methods `POST, OPTIONS` |
| `POST initialize` | **200**, correct `serverInfo` |
| `POST tools/list` | `[search_docs, read_page]` |
| `POST tools/call search_docs` | real doc results |

`pnpm run lint` and `pnpm run typecheck` both clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)