### PR TITLE
test(integration): assert contracts, not volatile live data

### DIFF
--- a/packages/tmdb/src/tests/configuration/configuration.integration.test.ts
+++ b/packages/tmdb/src/tests/configuration/configuration.integration.test.ts
@@ -38,14 +38,18 @@ describe("Configuration API", () => {
 	it("(COUNTRIES) should get list of countries used in TMDB", async () => {
 		const countries = await tmdb.configuration.countries();
 		expect(countries.length).toBeGreaterThan(0);
-		expect(countries[0].iso_3166_1).toBe("AD");
+		// Don't depend on list ordering; assert the country is present by ISO code.
+		expect(countries.some((c) => c.iso_3166_1 === "AD")).toBe(true);
 	});
 
 	it("(COUNTRIES) should get list of countries used in TMDB with specifed language", async () => {
 		const countries = await tmdb.configuration.countries({ language: "it-IT" });
 		expect(countries.length).toBeGreaterThan(1);
-		expect(countries[1]).toBeDefined();
-		expect(countries[1].native_name).toBe("Emirati Arabi Uniti");
+		// Find by ISO code instead of a fixed index; the localized native_name
+		// for AE (Italian) is the meaningful assertion here.
+		const ae = countries.find((c) => c.iso_3166_1 === "AE");
+		expect(ae).toBeDefined();
+		expect(ae?.native_name).toBe("Emirati Arabi Uniti");
 	});
 
 	it("(JOBS) should get list of jobs used in TMDB", async () => {

--- a/packages/tmdb/src/tests/movies/movies.integration.test.ts
+++ b/packages/tmdb/src/tests/movies/movies.integration.test.ts
@@ -64,7 +64,8 @@ describe("Movies (integration)", () => {
 		expect(credits.id).toBe(movie_id);
 		expect(credits.cast.length).toBeGreaterThan(0);
 		expect(credits.crew.length).toBeGreaterThan(0);
-		expect(credits.cast[0].name).toBe("Edward Norton");
+		// Billing order can change; assert the actor is present rather than first.
+		expect(credits.cast.some((member) => member.name === "Edward Norton")).toBe(true);
 	});
 
 	it("(MOVIE EXTERNAL IDS) should get movie external IDs", async () => {
@@ -91,8 +92,11 @@ describe("Movies (integration)", () => {
 		const changes = await tmdb.movies.changes({ movie_id, start_date, end_date });
 		expect(changes).toBeDefined();
 		expect(changes.changes).toBeDefined();
-		expect(changes.changes[0].key).toBe("images");
-		expect(changes.changes[0].items.length).toBeGreaterThan(0);
+		// The change feed is unordered; find the "images" change rather than
+		// assuming it is first.
+		const imagesChange = changes.changes.find((c) => c.key === "images");
+		expect(imagesChange).toBeDefined();
+		expect(imagesChange!.items.length).toBeGreaterThan(0);
 	});
 
 	it("(MOVIE IMAGES) should get movie images", async () => {

--- a/packages/tmdb/src/tests/search/search.integration.test.ts
+++ b/packages/tmdb/src/tests/search/search.integration.test.ts
@@ -36,14 +36,27 @@ describe("Search (integration)", () => {
 	});
 
 	it("(SEARCH MOVIE) should allow explicit params to override default options", async () => {
-		const tmdb = new TMDB(token, { language: "it", region: "IT" });
+		// Capture the outgoing request params via a request interceptor so we can
+		// assert the override contract on the request itself — localized response
+		// content is too volatile to prove which language was actually sent.
+		let capturedParams: Record<string, unknown> | undefined;
+		const tmdb = new TMDB(token, {
+			language: "it",
+			region: "IT",
+			interceptors: {
+				request: (ctx) => {
+					capturedParams = ctx.params;
+				},
+			},
+		});
 		const movies = await tmdb.search.movies({ query: "Fight Club", language: "en" });
 
-		expect(movies.page).toBe(1);
-		expect(movies.total_results).toBeGreaterThan(0);
-		expect(movies.results.length).toBeGreaterThan(0);
+		// Explicit language wins over the constructor default...
+		expect(capturedParams?.language).toBe("en");
+		// ...while an un-overridden default (region) is preserved.
+		expect(capturedParams?.region).toBe("IT");
 
-		// Fight Club (id 550) should be present regardless of ranking.
+		// Sanity check the live response: Fight Club (id 550) should be present.
 		expect(movies.results.some((m) => m.id === 550)).toBe(true);
 	});
 

--- a/packages/tmdb/src/tests/search/search.integration.test.ts
+++ b/packages/tmdb/src/tests/search/search.integration.test.ts
@@ -13,7 +13,9 @@ describe("Search (integration)", () => {
 		expect(movies.page).toBe(1);
 		expect(movies.total_results).toBeGreaterThan(0);
 		expect(movies.results.length).toBeGreaterThan(0);
-		expect(movies.results[0].title).toBe("Fight Club");
+		// Result ranking can shift; assert the expected movie is present by its
+		// stable TMDB id rather than at a fixed index.
+		expect(movies.results.some((m) => m.id === 550)).toBe(true);
 	});
 
 	it("(SEARCH MOVIE) should merge default options (language, region) into search params", async () => {
@@ -41,8 +43,8 @@ describe("Search (integration)", () => {
 		expect(movies.total_results).toBeGreaterThan(0);
 		expect(movies.results.length).toBeGreaterThan(0);
 
-		// Expect movie title to be in English since we overrode the default
-		expect(movies.results[0].title).toBe("Fight Club");
+		// Fight Club (id 550) should be present regardless of ranking.
+		expect(movies.results.some((m) => m.id === 550)).toBe(true);
 	});
 
 	it("(SEARCH COLLECTIONS) should search for a collection", async () => {
@@ -89,8 +91,10 @@ describe("Search (integration)", () => {
 		expect(persons.page).toBe(1);
 		expect(persons.total_results).toBeGreaterThan(0);
 		expect(persons.results.length).toBeGreaterThan(0);
-		expect(persons.results[0].name).toBe("Brad Pitt");
-		expect(persons.results[0].known_for[0].media_type).toBe("movie");
+		// Anchor to Brad Pitt's stable id; known_for ordering reranks by popularity.
+		const brad = persons.results.find((p) => p.id === 287);
+		expect(brad).toBeDefined();
+		expect(brad!.known_for.length).toBeGreaterThan(0);
 	});
 
 	it("(SEARCH TV SERIES) should search for a TV series", async () => {
@@ -100,7 +104,8 @@ describe("Search (integration)", () => {
 		expect(results.page).toBe(1);
 		expect(results.total_results).toBeGreaterThan(0);
 		expect(results.results.length).toBeGreaterThan(0);
-		expect(results.results[0].name).toBe("Breaking Bad");
+		// Assert Breaking Bad (id 1396) is present rather than top-ranked.
+		expect(results.results.some((r) => r.id === 1396)).toBe(true);
 	});
 
 	it("(SEARCH TV SERIES) should filter by first_air_date_year", async () => {
@@ -108,7 +113,10 @@ describe("Search (integration)", () => {
 		const results = await tmdb.search.tv_series({ query: "Breaking Bad", first_air_date_year: 2008 });
 
 		expect(results.total_results).toBeGreaterThan(0);
-		expect(results.results[0].first_air_date).toMatch(/^2008/);
+		// Verify the year filter by locating Breaking Bad (id 1396) and checking
+		// its air date, independent of result ordering.
+		const bb = results.results.find((r) => r.id === 1396);
+		expect(bb?.first_air_date).toMatch(/^2008/);
 	});
 
 	it("(SEARCH TV SERIES) should merge default language into params", async () => {

--- a/packages/tmdb/src/tests/tv_episodes/tv_episodes.integration.test.ts
+++ b/packages/tmdb/src/tests/tv_episodes/tv_episodes.integration.test.ts
@@ -51,7 +51,11 @@ describe("TV Episodes API", () => {
 	it("(TRANSLATIONS) should get images for a tv episode", async () => {
 		const results = await tmdb.tv_episodes.translations({ ...params });
 		expect(Array.isArray(results.translations)).toBe(true);
-		expect(results.translations[0].data.name).toBeDefined();
+		expect(results.translations.length).toBeGreaterThan(0);
+		// data.* fields are optional; assert the required translation wrapper shape.
+		expect(typeof results.translations[0].iso_639_1).toBe("string");
+		expect(typeof results.translations[0].name).toBe("string");
+		expect(results.translations[0].data).toBeDefined();
 	});
 
 	it("(VIDEOS) should get videos for a tv episode", async () => {

--- a/packages/tmdb/src/tests/tv_seasons/tv_seasons.integration.test.ts
+++ b/packages/tmdb/src/tests/tv_seasons/tv_seasons.integration.test.ts
@@ -67,7 +67,11 @@ describe("TV Seasons API", () => {
 	it("(TRANSLATIONS) should get translations for a tv season", async () => {
 		const results = await tmdb.tv_seasons.translations({ ...params });
 		expect(Array.isArray(results.translations)).toBe(true);
-		expect(results.translations[0].data.name).toBeDefined();
+		expect(results.translations.length).toBeGreaterThan(0);
+		// data.* fields are optional; assert the required translation wrapper shape.
+		expect(typeof results.translations[0].iso_639_1).toBe("string");
+		expect(typeof results.translations[0].name).toBe("string");
+		expect(results.translations[0].data).toBeDefined();
 	});
 
 	it("(VIDEOS) should get videos for a tv season", async () => {

--- a/packages/tmdb/src/tests/tv_seasons/tv_seasons.integration.test.ts
+++ b/packages/tmdb/src/tests/tv_seasons/tv_seasons.integration.test.ts
@@ -36,7 +36,7 @@ describe("TV Seasons API", () => {
 		expect(credits.id).toBeDefined();
 		expect(Array.isArray(credits.cast)).toBe(true);
 		expect(Array.isArray(credits.crew)).toBe(true);
-		expect(credits.cast[0].name).toBe("Bryan Cranston");
+		expect(credits.cast.some((member) => member.name === "Bryan Cranston")).toBe(true);
 	});
 
 	it("(CHANGES) should get changes for a tv season", async () => {

--- a/packages/tmdb/src/tests/tv_series/tv_series.integration.test.ts
+++ b/packages/tmdb/src/tests/tv_series/tv_series.integration.test.ts
@@ -142,7 +142,12 @@ describe("TV Series (integration)", () => {
 		// assert the field shape rather than an exact value at a fixed index.
 		const german = show.translations.find((t) => t.iso_639_1 === "de");
 		expect(german).toBeDefined();
-		expect(typeof german?.data.tagline).toBe("string");
+		// data.* fields are all optional (may be absent even when the translation
+		// exists), so assert the required wrapper fields, not a translated value.
+		expect(typeof german?.iso_3166_1).toBe("string");
+		expect(typeof german?.name).toBe("string");
+		expect(typeof german?.english_name).toBe("string");
+		expect(german?.data).toBeDefined();
 	});
 
 	it("(VIDEOS) should get tv shows videos", async () => {

--- a/packages/tmdb/src/tests/tv_series/tv_series.integration.test.ts
+++ b/packages/tmdb/src/tests/tv_series/tv_series.integration.test.ts
@@ -81,7 +81,7 @@ describe("TV Series (integration)", () => {
 	});
 
 	it("(IMAGES LANGUAGE) should get images for a tv show including specified language", async () => {
-		const show = await tmdb.tv_series.images({ series_id: 1399, include_image_language: "es-ES" });
+		const show = await tmdb.tv_series.images({ series_id: 1399, include_image_language: ["es-ES"] });
 		expect(Array.isArray(show.backdrops)).toBe(true);
 		expect(Array.isArray(show.posters)).toBe(true);
 		// include_image_language should surface Spanish images; assert one exists

--- a/packages/tmdb/src/tests/tv_series/tv_series.integration.test.ts
+++ b/packages/tmdb/src/tests/tv_series/tv_series.integration.test.ts
@@ -23,14 +23,18 @@ describe("TV Series (integration)", () => {
 		expect(show.id).toBe(1396);
 		expect(Array.isArray(show.cast)).toBe(true);
 		expect(Array.isArray(show.crew)).toBe(true);
-		expect(show.cast[0].name).toBe("Bryan Cranston");
+		expect(show.cast.some((member) => member.name === "Bryan Cranston")).toBe(true);
 	});
 
 	it("(ALTERNATIVE TITLES) should get alternative titles for a tv show", async () => {
 		const show = await tmdb.tv_series.alternative_titles({ series_id: 1396 });
 		expect(show.id).toBe(1396);
 		expect(Array.isArray(show.results)).toBe(true);
-		expect(show.results[1].title).toBe("Breaking Bad: A Química do Mal");
+		expect(show.results.length).toBeGreaterThan(0);
+		// Alternative titles are community-editable — order and contents change
+		// over time — so assert entry shape, not a specific title at a fixed index.
+		expect(typeof show.results[0].title).toBe("string");
+		expect(typeof show.results[0].iso_3166_1).toBe("string");
 	});
 
 	it("(CHANGES) should get changes for a tv show", async () => {
@@ -41,21 +45,26 @@ describe("TV Series (integration)", () => {
 	it("(CONTENT RATINGS) should get content ratings for a tv show", async () => {
 		const show = await tmdb.tv_series.content_ratings({ series_id: 1396 });
 		expect(Array.isArray(show.results)).toBe(true);
-		expect(show.results[0].iso_3166_1).toBe("DE");
-		expect(show.results[0].rating).toBe("16");
+		// Ratings are region-keyed and editable; find by ISO code instead of
+		// assuming a fixed index, and assert the rating shape not its value.
+		const de = show.results.find((r) => r.iso_3166_1 === "DE");
+		expect(de).toBeDefined();
+		expect(typeof de?.rating).toBe("string");
 	});
 
 	it("(CREDITS) should get credits for a tv show", async () => {
 		const show = await tmdb.tv_series.credits({ series_id: 1396 });
 		expect(Array.isArray(show.cast)).toBe(true);
-		expect(show.cast[0].name).toBe("Bryan Cranston");
+		expect(show.cast.some((member) => member.name === "Bryan Cranston")).toBe(true);
 	});
 
 	it("(EPISODE GROUPS) should get episode groups for a tv show", async () => {
 		const show = await tmdb.tv_series.episode_groups({ series_id: 1399 });
 		expect(Array.isArray(show.results)).toBe(true);
-		expect(show.results[0].episode_count).toBe(102);
-		expect(show.results[0].network.name).toBe("HBO");
+		expect(show.results.length).toBeGreaterThan(0);
+		// Episode groups are community-created; counts and ordering change, so
+		// assert shape across entries rather than a fixed group's contents.
+		expect(show.results.every((group) => typeof group.episode_count === "number")).toBe(true);
 	});
 
 	it("(EXTERNAL IDS) should get external ids for a tv show", async () => {
@@ -75,7 +84,9 @@ describe("TV Series (integration)", () => {
 		const show = await tmdb.tv_series.images({ series_id: 1399, include_image_language: "es-ES" });
 		expect(Array.isArray(show.backdrops)).toBe(true);
 		expect(Array.isArray(show.posters)).toBe(true);
-		expect(show.backdrops[0].iso_639_1).toBe("es");
+		// include_image_language should surface Spanish images; assert one exists
+		// rather than assuming it lands at a fixed index.
+		expect(show.backdrops.some((b) => b.iso_639_1 === "es")).toBe(true);
 	});
 
 	it("(KEYWORDS) should get keywords for a tv show", async () => {
@@ -92,8 +103,10 @@ describe("TV Series (integration)", () => {
 	it("(LISTS) should get tv show lists", async () => {
 		const show = await tmdb.tv_series.lists({ series_id: 1399 });
 		expect(Array.isArray(show.results)).toBe(true);
-		expect(show.results[0].item_count).toBeGreaterThan(0);
-		expect(show.results[0].iso_3166_1).toBe("IT");
+		expect(show.results.length).toBeGreaterThan(0);
+		// Public lists containing the show churn constantly; assert entry shape
+		// instead of a specific list's region/size at a fixed index.
+		expect(show.results.every((list) => typeof list.id === "number")).toBe(true);
 	});
 
 	it("(RECOMMENDATIONS) should get tv show recommendations", async () => {
@@ -105,7 +118,10 @@ describe("TV Series (integration)", () => {
 	it("(REVIEWS) should get tv show reviews", async () => {
 		const show = await tmdb.tv_series.reviews({ series_id: 1399, language: "en-US" });
 		expect(Array.isArray(show.results)).toBe(true);
-		expect(show.results[0].id).toBe("58aa82f09251416f92006a3a");
+		expect(show.results.length).toBeGreaterThan(0);
+		// Reviews are user content (added/removed/reordered); assert shape, not a
+		// specific review id at a fixed index.
+		expect(typeof show.results[0].id).toBe("string");
 	});
 
 	it("(SCREENED THEATRICALLY) should get tv episodes screened thetrically", async () => {
@@ -122,15 +138,21 @@ describe("TV Series (integration)", () => {
 	it("(TRANSLATIONS) should get tv shows translations", async () => {
 		const show = await tmdb.tv_series.translations({ series_id: 1399 });
 		expect(Array.isArray(show.translations)).toBe(true);
-		expect(show.translations[0].iso_3166_1).toBe("US");
-		expect(show.translations[1].data.tagline).toBe("Das Lied von Eis und Feuer");
+		// Translations are unordered and editable; find by language code and
+		// assert the field shape rather than an exact value at a fixed index.
+		const german = show.translations.find((t) => t.iso_639_1 === "de");
+		expect(german).toBeDefined();
+		expect(typeof german?.data.tagline).toBe("string");
 	});
 
 	it("(VIDEOS) should get tv shows videos", async () => {
 		const show = await tmdb.tv_series.videos({ series_id: 1399 });
 		expect(Array.isArray(show.results)).toBe(true);
-		expect(show.results[0].site).toBe("YouTube");
-		expect(show.results[0].official).toBe(true);
+		expect(show.results.length).toBeGreaterThan(0);
+		// Videos are added/reordered over time; assert entry shape rather than a
+		// specific video's platform/flag at a fixed index.
+		expect(typeof show.results[0].site).toBe("string");
+		expect(typeof show.results[0].key).toBe("string");
 	});
 
 	it("(WATCH PROVIDERS) should get tv shows watch providers", async () => {


### PR DESCRIPTION
## Problem

Integration CI was failing, and the root cause is a class of fragile assertions — not a one-off. Multiple integration tests asserted **exact content at a fixed index of live, community-editable TMDB data**. That data reorders and changes over time, so the tests were inherently flaky.

The current failure:

```
× (ALTERNATIVE TITLES) should get alternative titles for a tv show
  expected 'В обувките на Сатаната' to be 'Breaking Bad: A Química do Mal'
```

`alternative_titles[1]` flipped from a Portuguese to a Bulgarian title as contributors edited the list. Because CI runs `test:integration` on every PR to `main`, this failure blocks unrelated PRs (e.g. the MCP 405 fix).

## What was fragile

Assertions keyed on a positional index into volatile live lists:

| Area | Was asserting |
|---|---|
| tv_series alt titles | `results[1].title === "..."` |
| tv_series content ratings | `results[0]` is DE / rating `"16"` |
| tv_series episode groups | `results[0]` count `102` / network HBO |
| tv_series reviews | `results[0].id === "<review id>"` |
| tv_series translations | `translations[1].data.tagline === "..."` |
| tv_series videos | `results[0].site === "YouTube"` / official |
| tv_series / tv_seasons / movies cast | `cast[0].name === "..."` (billing order) |
| tv_series lists | `results[0]` region/size |
| tv_series images | `backdrops[0].iso_639_1 === "es"` |
| search | `results[0]` is Fight Club / Brad Pitt / Breaking Bad; `known_for[0]` |
| movies changes | `changes[0].key === "images"` |
| configuration | `countries[0]`/`[1]` by position |

## Approach

Validate the **API/SDK contract**, not TMDB's data content:

- **Anchor to stable identifiers** via `.find()` / `.some()` — movie/person/series IDs (550, 287, 1396), ISO codes (`DE`, `AE`, `de`) — instead of positional indices.
- **Assert shape/type** (`typeof`, array-ness, non-empty) where no stable anchor exists (alt titles, reviews, videos, episode-group counts, public lists).
- **Keep** deterministic lookups (find-by-external-id returns a single match) and existing type checks — those aren't fragile.

Meaningful coverage is preserved (e.g. the Italian `native_name` for `AE`, the 2008 air-date filter verified against Breaking Bad by id, language-filtered Spanish images present) — just decoupled from ordering.

## Verification

- No production code touched — tests only.
- `pnpm run typecheck` + `pnpm run lint` clean.
- `pnpm run test:integration`: **155 passed (24 files)**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)