### PR TITLE
ci: add lint and typecheck jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,56 @@ on:
         branches: [main, develop]
 
 jobs:
+    lint:
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v4
+
+            - name: Setup action
+              uses: pnpm/action-setup@v4
+              with:
+                  version: 9.15.9
+                  run_install: false
+
+            - name: Set up Node.js
+              uses: actions/setup-node@v5
+              with:
+                  node-version: 20
+                  cache: pnpm
+
+            - name: Install dependencies
+              run: pnpm install --frozen-lockfile
+
+            - name: Lint
+              run: pnpm run lint:check
+
+    typecheck:
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v4
+
+            - name: Setup action
+              uses: pnpm/action-setup@v4
+              with:
+                  version: 9.15.9
+                  run_install: false
+
+            - name: Set up Node.js
+              uses: actions/setup-node@v5
+              with:
+                  node-version: 20
+                  cache: pnpm
+
+            - name: Install dependencies
+              run: pnpm install --frozen-lockfile
+
+            - name: Typecheck
+              run: pnpm run typecheck
+
     unit-tests:
         runs-on: ubuntu-latest
 

--- a/turbo.json
+++ b/turbo.json
@@ -18,7 +18,7 @@
 			"cache": false
 		},
 		"lint:check": {
-			"dependsOn": ["^lint:check"],
+			"dependsOn": ["^build", "^lint:check"],
 			"cache": false
 		},
 		"format": {
@@ -42,7 +42,7 @@
 			"cache": false
 		},
 		"typecheck": {
-			"dependsOn": ["^typecheck"],
+			"dependsOn": ["^build", "^typecheck"],
 			"cache": false
 		}
 	}


### PR DESCRIPTION
## What

Adds **lint** and **typecheck** as two separate jobs inside the existing CI workflow (`.github/workflows/ci.yml`):

- **lint** → `pnpm run lint:check` (type-aware `oxlint`)
- **typecheck** → `pnpm run typecheck` (`tsc --noEmit`)

## Why

CI previously covered only unit and integration tests. These add lint and typecheck as independent required checks, kept as separate jobs so each reports its own status.

## Root-cause fix

Made the turbo `typecheck` and `lint:check` tasks depend on `^build`. A dependent package (`apps/docs`) imports `@lorenzopant/tmdb`, which resolves to the package's `dist/*.d.mts`. On a fresh CI checkout that output does not exist yet, so type-check / type-aware lint failed with `Cannot find module '@lorenzopant/tmdb'`. Depending on `^build` builds the upstream package first.

## Details

- Jobs trigger on push and PRs to `main` and `develop`.
- Mirror the existing `unit-tests` setup: pnpm `9.15.9`, Node `20`, pnpm cache, `--frozen-lockfile`.
- No secrets required → also run on fork PRs.
- `lint:check` chosen over plain `lint` — type-aware and non-mutating.

Verified locally with `dist/` removed: both pass (build runs first).

🤖 Generated with [Claude Code](https://claude.com/claude-code)