### PR TITLE
perf(docs): cut edge & serverless usage (proxy matcher + dynamicParams)

### DIFF
--- a/apps/docs/app/docs/[[...slug]]/page.tsx
+++ b/apps/docs/app/docs/[[...slug]]/page.tsx
@@ -37,6 +37,10 @@ export default async function Page(props: PageProps<"/docs/[[...slug]]">) {
 	);
 }
 
+// Unknown slugs (bot/scanner probes) return a static 404 instead of spinning
+// up a Serverless Function to render notFound(). Real pages are all prebuilt.
+export const dynamicParams = false;
+
 export async function generateStaticParams() {
 	return source.generateParams();
 }

--- a/apps/docs/app/llms.mdx/docs/[[...slug]]/route.ts
+++ b/apps/docs/app/llms.mdx/docs/[[...slug]]/route.ts
@@ -3,6 +3,8 @@ import { source } from "@/lib/source";
 import { notFound } from "next/navigation";
 
 export const revalidate = false;
+// Unknown slugs 404 statically; no Serverless Function for bot-probed paths.
+export const dynamicParams = false;
 
 export async function GET(_req: Request, { params }: RouteContext<"/llms.mdx/docs/[[...slug]]">) {
 	const { slug } = await params;

--- a/apps/docs/app/og/docs/[...slug]/route.tsx
+++ b/apps/docs/app/og/docs/[...slug]/route.tsx
@@ -4,6 +4,8 @@ import { ImageResponse } from "@takumi-rs/image-response";
 import { generate as DefaultImage } from "fumadocs-ui/og/takumi";
 
 export const revalidate = false;
+// Unknown slugs 404 statically; no Serverless Function for bot-probed paths.
+export const dynamicParams = false;
 
 export async function GET(_req: Request, { params }: RouteContext<"/og/docs/[...slug]">) {
 	const { slug } = await params;

--- a/apps/docs/app/proxy.ts
+++ b/apps/docs/app/proxy.ts
@@ -14,3 +14,10 @@ export default function proxy(request: NextRequest) {
 
 	return NextResponse.next();
 }
+
+// Only run on /docs/* — the only paths where markdown negotiation applies.
+// Without a matcher the proxy runs as an Edge Function on every request
+// (static assets, RSC prefetches, og, api, favicon), each a billed no-op.
+export const config = {
+	matcher: ["/docs/:path*"],
+};


### PR DESCRIPTION
## Problem

The docs app was racking up ~1M **Edge Function** calls and ~1M **Function Invocations** over a 30-day window.

## Root causes

**Edge (~1M):** `app/proxy.ts` (Next 16 middleware) had **no `config.matcher`** → ran as an Edge Function on *every* request, before cache: `_next/static/*` chunks, `_next/image`, RSC prefetches, og, api, favicon. Each run just called `rewriteLLM()` → null on non-docs paths → `NextResponse.next()`. A billed no-op, ~10–30× per page view.

**Function Invocations (partial):** the catch-all routes (`docs/[[...slug]]`, `llms.mdx/docs/[[...slug]]`, `og/docs/[...slug]`) are prebuilt via `generateStaticParams`, but `dynamicParams` defaults **true** → any unknown path (bot/vuln-scanner/crawler probe) rendered on-demand as a Serverless Function just to return `notFound()`.

## Changes (both zero behavior change)

- **`proxy.ts`**: add `config.matcher: ["/docs/:path*"]` — the only paths where markdown negotiation applies. Non-docs requests were already no-ops; they now simply don't invoke the edge function.
- **docs page / llms.mdx route / og route**: `export const dynamicParams = false` — unknown slugs return a **static 404** instead of a function. All real pages are prebuilt, so legitimate traffic is unaffected.

## Safety

- No user-facing behavior change. Proxy still handles `/docs/*` markdown negotiation; real pages still render; nonexistent paths still 404 (just statically).
- `pnpm --filter docs typecheck` passes.

## Not included (follow-up)

- Static/client-side search (`staticGET` + `RootProvider type: "static"`) — real UX change, worth a separate PR to eyeball the search box.
- Optional WAF/bot rules for `/mcp` + `/api`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)