### PR TITLE
fix(tmdb): treat ChangeItem value/original_value as opaque in drift check

### DIFF
--- a/packages/tmdb/src/drift/key-tree.test.ts
+++ b/packages/tmdb/src/drift/key-tree.test.ts
@@ -140,4 +140,41 @@ describe("keyTree (unit)", () => {
 			"certifications.{}[].order",
 		]);
 	});
+
+	it("records value/original_value as leaves without descending into their contents", () => {
+		const value = {
+			changes: [
+				{
+					key: "images",
+					items: [
+						{
+							id: "abc",
+							action: "added",
+							time: "2024-12-20 00:00:00 UTC",
+							value: { poster: { file_path: "/x.jpg", iso_639_1: "en" } },
+							original_value: { poster: { file_path: "/y.jpg", iso_639_1: "en" } },
+						},
+					],
+				},
+			],
+		};
+
+		expect(keyTree(value)).toEqual([
+			"changes",
+			"changes[].items",
+			"changes[].items[].action",
+			"changes[].items[].id",
+			"changes[].items[].original_value",
+			"changes[].items[].time",
+			"changes[].items[].value",
+			"changes[].key",
+		]);
+	});
+
+	it("is blind to new/changed nested fields inside value/original_value (TMDB varies these per change kind)", () => {
+		const before = { value: { poster: { file_path: "/x.jpg" } } };
+		const after = { value: { title_logo: { file_path: "/x.jpg", iso_639_1: "en" } } };
+
+		expect(keyTree(before)).toEqual(keyTree(after));
+	});
 });

--- a/packages/tmdb/src/drift/key-tree.ts
+++ b/packages/tmdb/src/drift/key-tree.ts
@@ -15,6 +15,16 @@ const DYNAMIC_KEY_PATTERNS: RegExp[] = [
 
 const DYNAMIC_KEY_SEGMENT = "{}";
 
+/**
+ * `ChangeItem.value` / `ChangeItem.original_value` (src/types/common/changes.ts) hold whatever
+ * payload TMDB's change-tracking endpoints attach for a given `key` (images, videos, cast,
+ * episode groups, ...). TMDB documents no schema for these and the shape varies by `key` — and
+ * by the day, as TMDB ships new change kinds. The type deliberately leaves them as `object | string`;
+ * `keyTree` must stop at the same boundary or every new/changed nested field reads as drift.
+ * These names are used nowhere else in src/types (verified via grep), so matching by name is safe.
+ */
+const OPAQUE_KEYS = new Set(["value", "original_value"]);
+
 function isPlainObject(value: unknown): value is Record<string, unknown> {
 	return typeof value === "object" && value !== null && !Array.isArray(value);
 }
@@ -47,6 +57,7 @@ function walk(value: unknown, prefix: string, paths: Set<string>): void {
 			const segment = isDynamicKey(key) ? DYNAMIC_KEY_SEGMENT : key;
 			const path = prefix ? `${prefix}.${segment}` : segment;
 			paths.add(path);
+			if (OPAQUE_KEYS.has(key)) continue;
 			walk(value[key], path, paths);
 		}
 		return;


### PR DESCRIPTION
## Summary
- `test:drift` was flagging false-positive drift on `movies.changes`, `tv_series.changes`, `tv_series.details+append` — live edits surfaced nested fields (`title_logo`, `poster`, cast/video/episode-group payloads) under `ChangeItem.value`/`original_value` that no type could ever fully declare.
- TMDB documents no schema for `value`/`original_value`; shape varies per change `key` and by the day as TMDB ships new change kinds ([tracking-content-changes docs](https://developer.themoviedb.org/docs/tracking-content-changes) confirm no stability guarantee). `ChangeItem` already models this loosely as `object | string` — `keyTree` just wasn't respecting that boundary on the live-response side.
- `keyTree` now stops recursing at `value`/`original_value` keys (verified via grep these names appear nowhere else in `src/types`), matching the type-tree walker's existing leaf treatment of bare `object`.

## Test plan
- [x] `pnpm test:drift` — 116/116 pass (was 113/116, 3 failing)
- [x] `pnpm check` (lint + typecheck + unit) — clean
- [x] New unit tests in `key-tree.test.ts` covering the opaque boundary and value-blindness to new nested fields