### PR TITLE
feat(tmdb): export ImageAPI for token-free image URL building

### DIFF
--- a/packages/tmdb/src/index.ts
+++ b/packages/tmdb/src/index.ts
@@ -10,6 +10,7 @@ export { V4ListsAPI } from "./endpoints/v4/lists";
 export { AuthenticationAPI } from "./endpoints/authentication";
 export { AccountAPI } from "./endpoints/account";
 export { GuestSessionsAPI } from "./endpoints/guest_sessions";
+export { ImageAPI } from "./images/images";
 export { ListsAPI } from "./endpoints/lists";
 export { CertificationsAPI } from "./endpoints/certifications";
 export { ChangesAPI } from "./endpoints/changes";


### PR DESCRIPTION
## Summary
- `ImageAPI` never needed an access token — its constructor only takes an optional `ImagesConfig`, and URL building (`buildUrl`) is pure string concatenation off the hardcoded `IMAGE_BASE_URL`/`IMAGE_SECURE_BASE_URL` constants.
- It was missing from `src/index.ts`, so consumers had no supported way to build image URLs without first constructing a full `TMDB` instance (which requires a token).
- Adds `export { ImageAPI } from "./images/images";` alongside the other endpoint exports.

## Test plan
- [x] `pnpm run test` — 699/699 tests pass (existing `ImageAPI` suite already exercises it standalone, no token, confirming the class works fine outside `TMDB`)
- [x] `pnpm lint` — 0 warnings/errors
- [x] `tsc --noEmit` — clean