### PR TITLE
perf(docs): serve documentation search index statically

### DIFF
--- a/apps/docs/app/api/search/route.ts
+++ b/apps/docs/app/api/search/route.ts
@@ -1,7 +1,14 @@
 import { source } from "@/lib/source";
 import { createFromSource } from "fumadocs-core/search/server";
 
-export const { GET } = createFromSource(source, {
+// Export the search index statically instead of running Orama on the server per
+// query. `staticGET` is prerendered at build time into a single cache-hit file;
+// the client (RootProvider search type: "static") downloads it once and runs all
+// querying in-browser. This removes the per-keystroke Serverless Function
+// invocations and Edge Requests that made /api/search a top-billed route.
+export const revalidate = false;
+
+export const { staticGET: GET } = createFromSource(source, {
 	// https://docs.orama.com/docs/orama-js/supported-languages
 	language: "english",
 });

--- a/apps/docs/app/layout.tsx
+++ b/apps/docs/app/layout.tsx
@@ -23,7 +23,7 @@ export default function Layout({ children }: LayoutProps<"/">) {
 				/>
 			</head>
 			<body className="flex flex-col min-h-screen">
-				<RootProvider>{children}</RootProvider>
+				<RootProvider search={{ options: { type: "static" } }}>{children}</RootProvider>
 				<Analytics />
 				<SpeedInsights />
 			</body>


### PR DESCRIPTION
## Why

Docs search ran server-side Orama on every debounced keystroke via `/api/search` — one server execution per query, and inherently uncacheable. Fumadocs supports exporting the index statically and querying entirely client-side, which is a better fit for a docs site whose content only changes at build time.

## What

Switch the docs search to fumadocs' **static search**:

- `app/api/search/route.ts` — export `staticGET` as `GET` (+ `revalidate = false`). The index is now prerendered at build into a single cache-hit file instead of computed per request.
- `app/layout.tsx` — `RootProvider search={{ options: { type: "static" } }}`. The browser downloads the index **once** and runs all querying client-side.

## Effect

- Build now emits `/api/search` as `○ (Static)` instead of `ƒ (Dynamic)`.
- Per-keystroke server work → gone; the client fetches one cached index and searches locally.
- Search behavior is unchanged for users (same dialog, same results source).

## Trade-offs

- The search index ships to the client. The docs set is small, so the payload is minor.

## Verification

`pnpm build` in `apps/docs` succeeds; typecheck passes; route table confirms `/api/search` is static and only `/mcp` remains dynamic.

> Note: also reduces Vercel Edge Requests and Function Invocations, since the per-keystroke requests to `/api/search` are eliminated.