### PR TITLE
test(tmdb): fix flaky changes assertion in TV details integration test

### DIFF
--- a/packages/tmdb/src/tests/tv_series/tv_series.details.integration.test.ts
+++ b/packages/tmdb/src/tests/tv_series/tv_series.details.integration.test.ts
@@ -108,7 +108,10 @@ describe("TV Series Details (integration)", () => {
 	it("(DETAILS + append: changes) should include changes", () => {
 		expect(show1396.changes).toBeDefined();
 		expect(Array.isArray(show1396.changes.changes)).toBe(true);
-		expect(show1396.changes.changes.length).toBeGreaterThan(0);
+		// `changes` reports edits within a default ~24h window, so the array is
+		// legitimately empty on days with no edits. Assert the contract (shape),
+		// not a non-zero count, which depends on volatile live TMDB activity.
+		expect(show1396.changes.changes.length).toBeGreaterThanOrEqual(0);
 	});
 
 	it("(DETAILS + append: content_ratings) should include content_ratings", () => {


### PR DESCRIPTION
## Problem

`test:integration` failed on:

```
tv_series.details.integration.test.ts > (DETAILS + append: changes) should include changes
AssertionError: expected 0 to be greater than 0
```

The `changes` append returns edits within TMDB's default ~24h window. Show `1396` (Breaking Bad, ended 2013) frequently has **zero** edits on any given day, so `expect(...changes.length).toBeGreaterThan(0)` depends on volatile live activity and fails whenever nobody edited that record recently.

## Fix

Assert the **contract** (defined + is-array + `length >= 0`) rather than a non-zero count. The shape checks on lines 109–110 already cover what the SDK guarantees; the non-empty check added only flakiness.

## Verification

`vitest run tv_series.details.integration` → 13/13 pass.