### PR TITLE
feat(tmdb): standalone /image subpath export for ImageAPI

### DIFF
--- a/packages/tmdb/README.md
+++ b/packages/tmdb/README.md
@@ -244,6 +244,23 @@ const tmdb = new TMDB(token, {
 });
 ```
 
+#### Standalone image URL builder
+
+Only need the image URL builder and not the rest of the SDK? Import `ImageAPI` from the
+`@lorenzopant/tmdb/image` subpath. It ships as its own ~3.4 kB bundle with no TMDB client and no
+endpoint code, so you don't pull in the full SDK:
+
+```typescript
+import { ImageAPI } from "@lorenzopant/tmdb/image";
+
+const images = new ImageAPI({ secure_images_url: true });
+
+const posterUrl = images.poster("/abc123.jpg", "w500");
+const backdropUrl = images.backdrop("/def456.jpg", "w1280");
+```
+
+`ImageAPI` needs no API token — it only builds URLs from paths.
+
 ### Error handling
 
 ```typescript

--- a/packages/tmdb/llms-full.txt
+++ b/packages/tmdb/llms-full.txt
@@ -169,6 +169,19 @@ const tmdb = new TMDB(token, {
 });
 ```
 
+### Standalone image URL builder (no SDK client)
+
+Import `ImageAPI` from the `@lorenzopant/tmdb/image` subpath when you only need to build image URLs
+and don't want to pull in the TMDB client or endpoint code. It ships as its own ~3.4 kB bundle and
+requires no API token.
+
+```ts
+import { ImageAPI } from "@lorenzopant/tmdb/image";
+
+const images = new ImageAPI({ secure_images_url: true });
+const posterUrl = images.poster("/abc123.jpg", "w500");
+```
+
 ### Paginate through any paginated endpoint
 
 ```ts

--- a/packages/tmdb/llms.txt
+++ b/packages/tmdb/llms.txt
@@ -33,6 +33,7 @@ Main exports:
 - Standalone endpoint classes like `MoviesAPI`, `SearchAPI`, `PeopleAPI`, `ListsAPI`, and `V4ListsAPI`
 - Utility exports including pagination helpers and `RetryOptions`
 - All public request/response types via `@lorenzopant/tmdb` and `@lorenzopant/tmdb/types`
+- `ImageAPI` standalone via `@lorenzopant/tmdb/image` — image URL builder as its own ~3.4 kB bundle, no TMDB client or endpoint code (use when you need only image URL building)
 
 Core namespaces on `TMDB`:
 - `movies`, `movie_lists`

--- a/packages/tmdb/package.json
+++ b/packages/tmdb/package.json
@@ -25,12 +25,17 @@
 		"llms-full.txt"
 	],
 	"type": "module",
+	"sideEffects": false,
 	"main": "dist/index.mjs",
 	"types": "dist/index.d.mts",
 	"exports": {
 		".": {
 			"import": "./dist/index.mjs",
 			"types": "./dist/index.d.mts"
+		},
+		"./image": {
+			"import": "./dist/image.mjs",
+			"types": "./dist/image.d.mts"
 		},
 		"./types": {
 			"import": "./dist/index.mjs",

--- a/packages/tmdb/src/image.ts
+++ b/packages/tmdb/src/image.ts
@@ -1,0 +1,14 @@
+// src/image.ts — standalone entry for the Image API (no SDK client, no endpoints).
+export { ImageAPI } from "./images/images";
+
+export type {
+	BackdropSize,
+	FallbackUrlConfig,
+	ImageSize,
+	ImagesConfig,
+	LogoSize,
+	PosterSize,
+	ProfileSize,
+	StillSize,
+} from "./types/config/images";
+export type { ImageCollectionKey } from "./types/common/images";

--- a/packages/tmdb/tsdown.config.ts
+++ b/packages/tmdb/tsdown.config.ts
@@ -3,6 +3,7 @@ import { defineConfig } from "tsdown";
 export default defineConfig({
 	entry: {
 		index: "src/index.ts",
+		image: "src/image.ts",
 	},
 	format: ["esm"],
 	dts: true,


### PR DESCRIPTION
## Problem

Consumers who only need the image URL builder had to import from the package root (`@lorenzopant/tmdb`), pulling in the whole SDK — the `TMDB` client and every endpoint class — even when unused. The package ships a single pre-bundled, minified `dist/index.mjs`, so tree-shaking couldn't reliably strip the rest.

## Fix

Add a dedicated `@lorenzopant/tmdb/image` subpath export backed by its own tsdown entry.

```ts
import { ImageAPI } from "@lorenzopant/tmdb/image";

const images = new ImageAPI({ secure_images_url: true });
const posterUrl = images.poster("/abc123.jpg", "w500");
```

- **~3.4 kB** image chunk vs **~59 kB** full entry. Verified the emitted chunk contains no endpoint classes, no `TMDB` client, no `fetch`.
- `ImageAPI` needs no API token — URL building only.
- Root import (`@lorenzopant/tmdb`) still exports `ImageAPI` — back-compatible.
- Added `"sideEffects": false` so bundler consumers can tree-shake the **main** entry too.

## Changes

- `src/image.ts` — new standalone entry (`ImageAPI` + its public types)
- `tsdown.config.ts` — emit `image` entry alongside `index`
- `package.json` — `./image` subpath export + `"sideEffects": false`
- `README.md` / `llms.txt` / `llms-full.txt` — document the standalone import

## Verification

- `pnpm run build` — emits `dist/image.mjs` (0.06 kB re-export → `images.mjs` 3.42 kB)
- `pnpm run typecheck` — passes

## Follow-ups (not in this PR)

- Changelog entry (`apps/docs/content/docs/changelog.mdx`) + minor version bump — public API addition. Left out per scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)