### PR TITLE
fix(types): preserve input type in image-path guards

### DIFF
--- a/apps/docs/content/docs/types/utility.mdx
+++ b/apps/docs/content/docs/types/utility.mdx
@@ -11,16 +11,21 @@ These are utility functions and types exported from `@lorenzopant/tmdb` for work
 
 ## Type Guards — Image Paths
 
-These type guards check whether an unknown object contains a specific image-path property with a non-null `string` value. They are useful when working with multi-media result types that may or may not carry a particular image field.
+These type guards check whether an object contains a specific image-path property with a non-null `string` value. They are useful when working with multi-media result types that may or may not carry a particular image field.
 
 ```ts
 import { hasPosterPath, hasBackdropPath, hasProfilePath, hasStillPath, hasLogoPath } from "@lorenzopant/tmdb";
 ```
 
+Each guard is generic over its input and narrows to `T & { <field>: string }`, so the input type survives the check. That matters in two places:
+
+- **Filtering.** `Array.prototype.filter` only applies its narrowing overload when the predicate type extends the element type. Because these guards intersect rather than replace, `movies.filter(hasPosterPath)` yields `(Movie & { poster_path: string })[]` — every other field is still there, and `poster_path` is `string` instead of `string | undefined`.
+- **Unknown input.** `unknown & { poster_path: string }` collapses to `{ poster_path: string }`, so passing a raw, untyped API response still works exactly as before.
+
 ### `hasPosterPath`
 
 ```ts
-function hasPosterPath(data: unknown): data is { poster_path: string };
+function hasPosterPath<T>(data: T): data is T & { poster_path: string };
 ```
 
 Returns `true` when `data` is an object with a `string` `poster_path` property.
@@ -32,12 +37,25 @@ if (hasPosterPath(result)) {
 }
 ```
 
+Filtering a typed list keeps the element type intact:
+
+```ts
+const { results } = await tmdb.movies.popular();
+
+const withPosters = results.filter(hasPosterPath);
+// (MovieResultItem & { poster_path: string })[]
+
+for (const movie of withPosters) {
+	console.log(movie.title, tmdb.images.poster(movie.poster_path));
+}
+```
+
 ---
 
 ### `hasBackdropPath`
 
 ```ts
-function hasBackdropPath(data: unknown): data is { backdrop_path: string };
+function hasBackdropPath<T>(data: T): data is T & { backdrop_path: string };
 ```
 
 Returns `true` when `data` is an object with a `string` `backdrop_path` property.
@@ -47,7 +65,7 @@ Returns `true` when `data` is an object with a `string` `backdrop_path` property
 ### `hasProfilePath`
 
 ```ts
-function hasProfilePath(data: unknown): data is { profile_path: string };
+function hasProfilePath<T>(data: T): data is T & { profile_path: string };
 ```
 
 Returns `true` when `data` is an object with a `string` `profile_path` property.
@@ -57,7 +75,7 @@ Returns `true` when `data` is an object with a `string` `profile_path` property.
 ### `hasStillPath`
 
 ```ts
-function hasStillPath(data: unknown): data is { still_path: string };
+function hasStillPath<T>(data: T): data is T & { still_path: string };
 ```
 
 Returns `true` when `data` is an object with a `string` `still_path` property.
@@ -67,7 +85,7 @@ Returns `true` when `data` is an object with a `string` `still_path` property.
 ### `hasLogoPath`
 
 ```ts
-function hasLogoPath(data: unknown): data is { logo_path: string };
+function hasLogoPath<T>(data: T): data is T & { logo_path: string };
 ```
 
 Returns `true` when `data` is an object with a `string` `logo_path` property.

--- a/packages/tmdb/src/tests/utils/types.test.ts
+++ b/packages/tmdb/src/tests/utils/types.test.ts
@@ -80,3 +80,68 @@ describe("image path type guards", () => {
 		expect(hasPosterPath(inherited)).toBe(false);
 	});
 });
+
+describe("image path type guards — narrowing", () => {
+	interface Movie {
+		id: number;
+		title: string;
+		poster_path?: string;
+	}
+
+	it("preserves the input type when filtering a typed array", () => {
+		const movies: Movie[] = [
+			{ id: 1, title: "With poster", poster_path: "/poster.jpg" },
+			{ id: 2, title: "Without poster" },
+		];
+
+		const withPosters = movies.filter(hasPosterPath);
+
+		// Type-level: `poster_path` is `string` (not `string | undefined`) and the
+		// rest of `Movie` survives. Both assignments fail to compile on regression.
+		const path: string = withPosters[0]!.poster_path;
+		const title: string = withPosters[0]!.title;
+
+		expect(withPosters).toHaveLength(1);
+		expect(path).toBe("/poster.jpg");
+		expect(title).toBe("With poster");
+	});
+
+	it("still narrows an unknown value to the image-path shape", () => {
+		const data: unknown = { poster_path: "/poster.jpg" };
+
+		if (!hasPosterPath(data)) throw new Error("expected poster_path");
+		const path: string = data.poster_path;
+
+		expect(path).toBe("/poster.jpg");
+	});
+
+	it("narrows a typed value without discarding its other properties", () => {
+		const movie: Movie = { id: 7, title: "Narrowed", poster_path: "/p.jpg" };
+
+		if (!hasPosterPath(movie)) throw new Error("expected poster_path");
+		const path: string = movie.poster_path;
+
+		expect(path).toBe("/p.jpg");
+		expect(movie.id).toBe(7);
+	});
+
+	it("narrows the remaining image-path guards the same way", () => {
+		const raw: unknown[] = [
+			{ backdrop_path: "/b.jpg" },
+			{ profile_path: "/pr.jpg" },
+			{ still_path: "/s.jpg" },
+			{ logo_path: "/l.png" },
+			{},
+		];
+
+		const backdrops: string[] = raw.filter(hasBackdropPath).map((item) => item.backdrop_path);
+		const profiles: string[] = raw.filter(hasProfilePath).map((item) => item.profile_path);
+		const stills: string[] = raw.filter(hasStillPath).map((item) => item.still_path);
+		const logos: string[] = raw.filter(hasLogoPath).map((item) => item.logo_path);
+
+		expect(backdrops).toEqual(["/b.jpg"]);
+		expect(profiles).toEqual(["/pr.jpg"]);
+		expect(stills).toEqual(["/s.jpg"]);
+		expect(logos).toEqual(["/l.png"]);
+	});
+});

--- a/packages/tmdb/src/utils/types.ts
+++ b/packages/tmdb/src/utils/types.ts
@@ -21,8 +21,13 @@ export function isPlainObject(value: unknown): value is Record<string, unknown> 
 
 // MARK: Images
 
-/** Utility type guard to check if an object has a poster_path property */
-export function hasPosterPath(data: unknown): data is { poster_path: string } {
+/**
+ * Utility type guard to check if an object has a poster_path property.
+ * Narrows to `T & { poster_path: string }` so the input type survives — this keeps
+ * the guard usable in `Array.prototype.filter`, whose narrowing overload requires
+ * the predicate type to extend the element type.
+ */
+export function hasPosterPath<T>(data: T): data is T & { poster_path: string } {
 	return (
 		typeof data === "object" &&
 		data !== null &&
@@ -31,8 +36,8 @@ export function hasPosterPath(data: unknown): data is { poster_path: string } {
 	);
 }
 
-/** Utility type guard to check if an object has a backdrop_path property */
-export function hasBackdropPath(data: unknown): data is { backdrop_path: string } {
+/** Utility type guard to check if an object has a backdrop_path property. Narrows to `T & { backdrop_path: string }`. */
+export function hasBackdropPath<T>(data: T): data is T & { backdrop_path: string } {
 	return (
 		typeof data === "object" &&
 		data !== null &&
@@ -41,8 +46,8 @@ export function hasBackdropPath(data: unknown): data is { backdrop_path: string 
 	);
 }
 
-/** Utility type guard to check if an object has a profile_path property */
-export function hasProfilePath(data: unknown): data is { profile_path: string } {
+/** Utility type guard to check if an object has a profile_path property. Narrows to `T & { profile_path: string }`. */
+export function hasProfilePath<T>(data: T): data is T & { profile_path: string } {
 	return (
 		typeof data === "object" &&
 		data !== null &&
@@ -51,8 +56,8 @@ export function hasProfilePath(data: unknown): data is { profile_path: string } 
 	);
 }
 
-/** Utility type guard to check if an object has a still_path property */
-export function hasStillPath(data: unknown): data is { still_path: string } {
+/** Utility type guard to check if an object has a still_path property. Narrows to `T & { still_path: string }`. */
+export function hasStillPath<T>(data: T): data is T & { still_path: string } {
 	return (
 		typeof data === "object" &&
 		data !== null &&
@@ -61,8 +66,8 @@ export function hasStillPath(data: unknown): data is { still_path: string } {
 	);
 }
 
-/** Utility type guard to check if an object has a logo_path property */
-export function hasLogoPath(data: unknown): data is { logo_path: string } {
+/** Utility type guard to check if an object has a logo_path property. Narrows to `T & { logo_path: string }`. */
+export function hasLogoPath<T>(data: T): data is T & { logo_path: string } {
 	return (
 		typeof data === "object" && data !== null && "logo_path" in data && typeof (data as Record<string, unknown>).logo_path === "string"
 	);


### PR DESCRIPTION
# Pull Request

## 📋 Description

The five image-path type guards (`hasPosterPath`, `hasBackdropPath`, `hasProfilePath`, `hasStillPath`, `hasLogoPath`) were declared as:

```ts
function hasPosterPath(data: unknown): data is { poster_path: string };
```

`Array.prototype.filter` only applies its narrowing overload `filter<S extends T>(pred: (v: T) => v is S): S[]` when the predicate type extends the element type. `{ poster_path: string }` does not extend `Movie`, so the overload never matched and TypeScript silently fell back to `filter(pred): T[]`:

```ts
const withPosters = movies.filter(hasPosterPath);
//    ^? Movie[]
withPosters[0].poster_path;
//             ^? string | undefined   ← no narrowing at all
```

The guard was a no-op in the position it's most useful. Note this is a *narrowing* failure, not a type-loss one — nothing was stripped from the element type, but nothing was gained either.

Direct calls already worked and are unchanged: `if (hasPosterPath(movie))` narrows to `Movie & { poster_path: string }`, since TS intersects when neither type is a subtype of the other.

### The fix

Make each guard generic over its input and narrow to an intersection:

```ts
function hasPosterPath<T>(data: T): data is T & { poster_path: string };
```

`S extends T` now holds, so `filter` narrows properly and every other field survives. Runtime bodies are untouched.

### Why the type parameter is unconstrained

The obvious alternative is `<T extends { poster_path?: string | null }>`. It fixes filtering, but rejects `unknown` — which is exactly what these guards are documented for ("narrowing image-path fields on unknown objects"). Leaving `T` unconstrained keeps both working, because `unknown & { poster_path: string }` collapses to `{ poster_path: string }`.

**Non-breaking.** Every previously-valid call site still compiles and produces the same or a strictly more precise type.

| Call | Before | After |
| --- | --- | --- |
| `movies.filter(hasPosterPath)` | `Movie[]` | `(Movie & { poster_path: string })[]` |
| `(Movie \| Tv)[].filter(...)` | `(Movie \| Tv)[]` | `((Movie \| Tv) & { poster_path: string })[]` |
| `unknown[].filter(...)` | `unknown[]` | `{ poster_path: string }[]` |
| `readonly Movie[].filter(...)` | `readonly Movie[]` → `Movie[]` | `(Movie & { poster_path: string })[]` |
| `hasPosterPath(unknownValue)` | `{ poster_path: string }` | `{ poster_path: string }` |
| `hasPosterPath(movie)` | `Movie & { poster_path: string }` | `Movie & { poster_path: string }` |
| assign to `(x: unknown) => boolean` | ok | ok |

## ✅ Checklist

- [x] My code follows the code style of this project
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] All tests pass locally
- [x] I have linted and formatted the code using `pnpm lint` and `pnpm format`

## 🧪 How Has This Been Tested?

Behavior here is entirely type-level, so the new tests in `src/tests/utils/types.test.ts` assert types by assignment — each one fails to **compile** on regression, and `pnpm typecheck` is the real gate:

- `movies.filter(hasPosterPath)` → assigns `.poster_path` to `string` (not `string | undefined`) **and** `.title` to `string`, proving both narrowing and type preservation.
- `unknown` input still narrows to `{ poster_path: string }`.
- Typed input narrows without discarding other properties.
- The other four guards narrow the same way through `filter(...).map(...)` into `string[]`.

Run from `packages/tmdb`:

```
pnpm run typecheck   # tsc --noEmit  — passes
pnpm run test:unit   # 48 files, 703 tests passed
pnpm run test:drift  # 2 files, 129 tests passed
pnpm run lint        # clean
pnpm run build       # emits the generic signatures into dist/index.d.mts
```

Existing runtime tests are unmodified and still pass — `null`, `42`, `"not-an-object"`, `Symbol()`, `[]`, and prototype-inherited keys all still return `false`.

## 💬 Additional Notes

- Docs updated in `apps/docs/content/docs/types/utility.mdx`: new signatures, an explanation of why the guards intersect rather than replace, and a filtering example.
- Changelog not touched — this repo adds entries at release time with the merged PR number.
