### PR TITLE
fix(endpoints): forward include_image_language on details() appends

### DIFF
--- a/apps/docs/content/docs/api-reference/movies/details.mdx
+++ b/apps/docs/content/docs/api-reference/movies/details.mdx
@@ -15,11 +15,33 @@ async details<T extends readonly MovieAppendToResponseNamespace[] = []>(
 
 ## Parameters
 
-| Name                 | Type                                                                                    | Required | Description                                          |
-| -------------------- | --------------------------------------------------------------------------------------- | -------- | ---------------------------------------------------- |
-| `movie_id`           | `number`                                                                                | ✅       | TMDB movie identifier.                               |
-| `append_to_response` | [`MovieAppendToResponseNamespace[]`](/docs/types/movies#movieappendtoresponsenamespace) | ❌       | Sub-resources to append to the response.             |
-| `language`           | [`Language`](/docs/types/options/language#language)                                     | ❌       | Language for localized results. Defaults to `en-US`. |
+| Name                     | Type                                                                                    | Required | Description                                                                 |
+| ------------------------ | --------------------------------------------------------------------------------------- | -------- | --------------------------------------------------------------------------- |
+| `movie_id`               | `number`                                                                                | ✅       | TMDB movie identifier.                                                      |
+| `append_to_response`     | [`MovieAppendToResponseNamespace[]`](/docs/types/movies#movieappendtoresponsenamespace) | ❌       | Sub-resources to append to the response.                                    |
+| `language`               | [`Language`](/docs/types/options/language#language)                                     | ❌       | Language for localized results. Defaults to `en-US`.                        |
+| `include_image_language` | `(Language \| "null")[]`                                                                | ❌       | Extra languages for an appended `images` block. Serialized comma-separated. |
+
+<Callout type="warn">
+	When you append `images` **and** pass a `language`, TMDB treats the language as a filter on the appended block and
+	returns only images tagged with it. Logos are always language-tagged and most backdrops are untagged, so both come back
+	empty. Pass `include_image_language` to get them:
+
+```ts
+const movie = await tmdb.movies.details({
+	movie_id: 550,
+	language: "it-IT",
+	append_to_response: ["images"],
+	include_image_language: ["null", "en"], // untagged + English
+});
+// 68 posters, 87 backdrops, 23 logos
+// without include_image_language: 3 posters, 0 backdrops, 0 logos
+```
+
+Use `"null"` for untagged images (textless posters, most backdrops), and pair it with at least one real language code —
+`["null"]` alone still returns zero logos.
+
+</Callout>
 
 ## Returns
 

--- a/apps/docs/content/docs/api-reference/tv-episodes/details.mdx
+++ b/apps/docs/content/docs/api-reference/tv-episodes/details.mdx
@@ -15,13 +15,32 @@ async details<T extends readonly TVEpisodeAppendToResponseNamespace[] = []>(
 
 ## Parameters
 
-| Name                 | Type                                                                                                 | Required | Description                                          |
-| -------------------- | ---------------------------------------------------------------------------------------------------- | -------- | ---------------------------------------------------- |
-| `series_id`          | `number`                                                                                             | ✅       | TMDB TV series identifier.                           |
-| `season_number`      | `number`                                                                                             | ✅       | Season number within the TV series.                  |
-| `episode_number`     | `number`                                                                                             | ✅       | Episode number within the season.                    |
-| `append_to_response` | [`TVEpisodeAppendToResponseNamespace[]`](/docs/types/tv-episodes#tvepisodeappendtoresponsenamespace) | ❌       | Sub-resources to append to the response.             |
-| `language`           | [`Language`](/docs/types/options/language#language)                                                  | ❌       | Language for localized results. Defaults to `en-US`. |
+| Name                     | Type                                                                                                 | Required | Description                                                                 |
+| ------------------------ | ---------------------------------------------------------------------------------------------------- | -------- | --------------------------------------------------------------------------- |
+| `series_id`              | `number`                                                                                             | ✅       | TMDB TV series identifier.                                                  |
+| `season_number`          | `number`                                                                                             | ✅       | Season number within the TV series.                                         |
+| `episode_number`         | `number`                                                                                             | ✅       | Episode number within the season.                                           |
+| `append_to_response`     | [`TVEpisodeAppendToResponseNamespace[]`](/docs/types/tv-episodes#tvepisodeappendtoresponsenamespace) | ❌       | Sub-resources to append to the response.                                    |
+| `language`               | [`Language`](/docs/types/options/language#language)                                                  | ❌       | Language for localized results. Defaults to `en-US`.                        |
+| `include_image_language` | `(Language \| "null")[]`                                                                             | ❌       | Extra languages for an appended `images` block. Serialized comma-separated. |
+
+<Callout type="warn">
+	When you append `images` **and** pass a `language`, TMDB treats the language as a filter on the appended block. Episode
+	stills are mostly untagged, so the block usually comes back empty — pass `include_image_language` with `"null"`:
+
+```ts
+const episode = await tmdb.tv_episodes.details({
+	series_id: 1396,
+	season_number: 1,
+	episode_number: 1,
+	language: "it-IT",
+	append_to_response: ["images"],
+	include_image_language: ["null", "en"], // untagged + English
+});
+// 6 stills — without include_image_language: 0
+```
+
+</Callout>
 
 ## Returns
 

--- a/apps/docs/content/docs/api-reference/tv-seasons/details.mdx
+++ b/apps/docs/content/docs/api-reference/tv-seasons/details.mdx
@@ -15,12 +15,30 @@ async details<T extends readonly TVSeasonAppendToResponseNamespace[] = []>(
 
 ## Parameters
 
-| Name                 | Type                                                                                              | Required | Description                                          |
-| -------------------- | ------------------------------------------------------------------------------------------------- | -------- | ---------------------------------------------------- |
-| `series_id`          | `number`                                                                                          | ✅       | TMDB TV series identifier.                           |
-| `season_number`      | `number`                                                                                          | ✅       | Season number within the TV series.                  |
-| `append_to_response` | [`TVSeasonAppendToResponseNamespace[]`](/docs/types/tv-seasons#tvseasonappendtoresponsenamespace) | ❌       | Sub-resources to append to the response.             |
-| `language`           | [`Language`](/docs/types/options/language#language)                                               | ❌       | Language for localized results. Defaults to `en-US`. |
+| Name                     | Type                                                                                              | Required | Description                                                                 |
+| ------------------------ | ------------------------------------------------------------------------------------------------- | -------- | --------------------------------------------------------------------------- |
+| `series_id`              | `number`                                                                                          | ✅       | TMDB TV series identifier.                                                  |
+| `season_number`          | `number`                                                                                          | ✅       | Season number within the TV series.                                         |
+| `append_to_response`     | [`TVSeasonAppendToResponseNamespace[]`](/docs/types/tv-seasons#tvseasonappendtoresponsenamespace) | ❌       | Sub-resources to append to the response.                                    |
+| `language`               | [`Language`](/docs/types/options/language#language)                                               | ❌       | Language for localized results. Defaults to `en-US`.                        |
+| `include_image_language` | `(Language \| "null")[]`                                                                          | ❌       | Extra languages for an appended `images` block. Serialized comma-separated. |
+
+<Callout type="warn">
+	When you append `images` **and** pass a `language`, TMDB treats the language as a filter on the appended block. Pass
+	`include_image_language` to widen it:
+
+```ts
+const season = await tmdb.tv_seasons.details({
+	series_id: 1396,
+	season_number: 1,
+	language: "it-IT",
+	append_to_response: ["images"],
+	include_image_language: ["null", "en"], // untagged + English
+});
+// 27 posters — without include_image_language: 2
+```
+
+</Callout>
 
 ## Returns
 

--- a/apps/docs/content/docs/api-reference/tv-series/details.mdx
+++ b/apps/docs/content/docs/api-reference/tv-series/details.mdx
@@ -15,11 +15,30 @@ async details<T extends readonly TVAppendToResponseNamespace[] = []>(
 
 ## Parameters
 
-| Name                 | Type                                                                                 | Required | Description                                          |
-| -------------------- | ------------------------------------------------------------------------------------ | -------- | ---------------------------------------------------- |
-| `series_id`          | `number`                                                                             | ✅       | TMDB TV series identifier.                           |
-| `append_to_response` | [`TVAppendToResponseNamespace[]`](/docs/types/tv-series#tvappendtoresponsenamespace) | ❌       | Sub-resources to append to the response.             |
-| `language`           | [`Language`](/docs/types/options/language#language)                                  | ❌       | Language for localized results. Defaults to `en-US`. |
+| Name                     | Type                                                                                 | Required | Description                                                                 |
+| ------------------------ | ------------------------------------------------------------------------------------ | -------- | --------------------------------------------------------------------------- |
+| `series_id`              | `number`                                                                             | ✅       | TMDB TV series identifier.                                                  |
+| `append_to_response`     | [`TVAppendToResponseNamespace[]`](/docs/types/tv-series#tvappendtoresponsenamespace) | ❌       | Sub-resources to append to the response.                                    |
+| `language`               | [`Language`](/docs/types/options/language#language)                                  | ❌       | Language for localized results. Defaults to `en-US`.                        |
+| `include_image_language` | `(Language \| "null")[]`                                                             | ❌       | Extra languages for an appended `images` block. Serialized comma-separated. |
+
+<Callout type="warn">
+	When you append `images` **and** pass a `language`, TMDB treats the language as a filter on the appended block and
+	returns only images tagged with it — often nothing at all. Pass `include_image_language` to get logos and untagged
+	backdrops:
+
+```ts
+const show = await tmdb.tv_series.details({
+	series_id: 1396,
+	language: "it-IT",
+	append_to_response: ["images"],
+	include_image_language: ["null", "en"], // untagged + English
+});
+// 108 posters, 124 backdrops, 9 logos
+// without include_image_language: 0 / 0 / 0
+```
+
+</Callout>
 
 ## Returns
 

--- a/apps/docs/content/docs/getting-started/options/images.mdx
+++ b/apps/docs/content/docs/getting-started/options/images.mdx
@@ -236,11 +236,19 @@ When `true`, the client automatically derives `include_image_language` from the 
 declared in `image_language_priority` and injects it into every `.images()` request. This ensures
 TMDB actually returns the language variants the priority config expects to sort.
 
+It also applies to `.details()` calls that ask for an images block via
+`append_to_response: ["images"]` — the appended block needs the same parameter to return logos and
+untagged artwork. Details calls that don't append images are left alone, since TMDB would ignore the
+parameter there.
+
 The injected value is the union of all language codes across all configured collections, with `"*"`
 excluded (it has no meaning as an HTTP query parameter). An explicit `include_image_language` at the
 call site always takes precedence.
 
 Requires `image_language_priority` to be configured; has no effect without it.
+
+Person images are unaffected — TMDB profile images carry no language tag, so neither
+`people.images()` nor `people.details()` accepts `include_image_language`.
 
 ```ts
 const tmdb = new TMDB(apiKey, {
@@ -260,12 +268,17 @@ const customImages = await tmdb.movies.images({
 	movie_id: 550,
 	include_image_language: ["fr", "null"],
 });
+
+// Also injected when details() appends an images block
+const movie = await tmdb.movies.details({ movie_id: 550, append_to_response: ["images"] });
+
+// Not injected here — no images block was requested
+const plain = await tmdb.movies.details({ movie_id: 550, append_to_response: ["credits"] });
 ```
 
 <Callout>
-	Enable `auto_include_image_language` together with `image_language_priority` for a fully automatic
-	setup: TMDB returns the right language variants **and** the client orders them according to your
-	priority list — all without any extra call-site code.
+	Enable `auto_include_image_language` together with `image_language_priority` for a fully automatic setup: TMDB returns the right
+	language variants **and** the client orders them according to your priority list — all without any extra call-site code.
 </Callout>
 
 ---
@@ -329,8 +342,8 @@ console.log(movie.backdrop_path); // "/placeholder.png" (was null)
 ```
 
 <Callout>
-	`image_language_priority` sorting applies only when `autocomplete_paths` is enabled. When only
-	`fallback_url` is set, collection array order is preserved as returned by the API.
+	`image_language_priority` sorting applies only when `autocomplete_paths` is enabled. When only `fallback_url` is set, collection array
+	order is preserved as returned by the API.
 </Callout>
 
 ---

--- a/apps/docs/content/docs/types/movies.mdx
+++ b/apps/docs/content/docs/types/movies.mdx
@@ -284,6 +284,10 @@ release-date window the list was queried over.
 		movie_id: { type: "number", required: true, description: "TMDB movie identifier." },
 		append_to_response: { type: "MovieAppendToResponseNamespace[]", description: "Sub-resources to append to the response." },
 		language: { type: "Language", description: "Language for localized results.", default: "en-US" },
+		include_image_language: {
+			type: '(Language | "null")[]',
+			description: 'Extra languages for an appended `images` block. Use "null" for untagged images. Serialized comma-separated.',
+		},
 	}}
 />
 

--- a/apps/docs/content/docs/types/tv-episodes.mdx
+++ b/apps/docs/content/docs/types/tv-episodes.mdx
@@ -102,6 +102,10 @@ Alias for [`VideoResults`](/docs/types/common#videoresults).
 		episode_number: { type: "number", required: true, description: "Episode number within the season." },
 		append_to_response: { type: "TVEpisodeAppendToResponseNamespace[]", description: "Sub-resources to append to the response." },
 		language: { type: "Language", description: "Language for localized results.", default: "en-US" },
+		include_image_language: {
+			type: '(Language | "null")[]',
+			description: 'Extra languages for an appended `images` block. Use "null" for untagged images. Serialized comma-separated.',
+		},
 	}}
 />
 

--- a/apps/docs/content/docs/types/tv-seasons.mdx
+++ b/apps/docs/content/docs/types/tv-seasons.mdx
@@ -120,6 +120,10 @@ Alias for [`VideoResults`](/docs/types/common#videoresults).
 		season_number: { type: "number", required: true, description: "Season number within the TV series." },
 		append_to_response: { type: "TVSeasonAppendToResponseNamespace[]", description: "Sub-resources to append to the response." },
 		language: { type: "Language", description: "Language for localized results.", default: "en-US" },
+		include_image_language: {
+			type: '(Language | "null")[]',
+			description: 'Extra languages for an appended `images` block. Use "null" for untagged images. Serialized comma-separated.',
+		},
 	}}
 />
 

--- a/apps/docs/content/docs/types/tv-series.mdx
+++ b/apps/docs/content/docs/types/tv-series.mdx
@@ -240,6 +240,10 @@ A [`PaginatedResponse`](/docs/types/common#paginatedresponset) of [`TVSeriesList
 		series_id: { type: "number", required: true, description: "TMDB TV series identifier." },
 		append_to_response: { type: "TVAppendToResponseNamespace[]", description: "Sub-resources to append to the response." },
 		language: { type: "Language", description: "Language for localized results.", default: "en-US" },
+		include_image_language: {
+			type: '(Language | "null")[]',
+			description: 'Extra languages for an appended `images` block. Use "null" for untagged images. Serialized comma-separated.',
+		},
 	}}
 />
 

--- a/packages/tmdb/src/endpoints/base.ts
+++ b/packages/tmdb/src/endpoints/base.ts
@@ -78,4 +78,22 @@ export abstract class TMDBAPIBase {
 		if (!langs.length) return params;
 		return { ...params, include_image_language: langs } as T;
 	}
+
+	/**
+	 * {@link injectImageLanguage} scoped to `details()` calls.
+	 *
+	 * A details request only carries an images block when `append_to_response`
+	 * asks for one, so the derived `include_image_language` is injected only in
+	 * that case — otherwise every details call would grow a query param TMDB
+	 * ignores, changing cache/dedup keys for no benefit.
+	 *
+	 * An explicit `include_image_language` on the call site is passed through
+	 * untouched either way.
+	 */
+	protected injectImageLanguageForAppends<T extends { append_to_response?: unknown }>(params: T): T {
+		const append = params.append_to_response;
+		const appends = Array.isArray(append) ? append : append === undefined ? [] : [append];
+		if (!appends.includes("images")) return params;
+		return this.injectImageLanguage(params);
+	}
 }

--- a/packages/tmdb/src/endpoints/base.ts
+++ b/packages/tmdb/src/endpoints/base.ts
@@ -92,7 +92,14 @@ export abstract class TMDBAPIBase {
 	 */
 	protected injectImageLanguageForAppends<T extends { append_to_response?: unknown }>(params: T): T {
 		const append = params.append_to_response;
-		const appends = Array.isArray(append) ? append : append === undefined ? [] : [append];
+		const entries = Array.isArray(append) ? append : append === undefined ? [] : [append];
+
+		// TMDB takes append_to_response as a comma-separated list and the endpoint JSDoc
+		// documents it that way, so "credits,images" has to resolve the same as
+		// ["credits", "images"]. Array entries are split too — an array holding a joined
+		// string is just as valid on the wire. Non-string entries can never be "images".
+		const appends = entries.flatMap((entry) => (typeof entry === "string" ? entry.split(",").map((name) => name.trim()) : []));
+
 		if (!appends.includes("images")) return params;
 		return this.injectImageLanguage(params);
 	}

--- a/packages/tmdb/src/endpoints/movies.ts
+++ b/packages/tmdb/src/endpoints/movies.ts
@@ -52,15 +52,18 @@ export class MoviesAPI extends TMDBAPIBase {
 	 * @param movie_id The ID of the movie.
 	 * @param append_to_response A comma-separated list of the fields to include in the response.
 	 * @param language The language to use for the response.
+	 * @param include_image_language Extra languages for an appended `images` block. `language`
+	 * alone filters it down to that language's tagged images only, which drops every logo and
+	 * untagged backdrop — pass `["null", "en"]` or similar to get them back.
 	 * @returns A promise that resolves to the movie details.
 	 * @reference https://developer.themoviedb.org/reference/movie-details
 	 */
 	async details<T extends readonly MovieAppendToResponseNamespace[] = []>(
 		params: MovieDetailsParams & { append_to_response?: T[number] | T },
 	): Promise<T extends [] ? MovieDetails : MovieDetailsWithAppends<T>> {
-		const { language = this.defaultOptions.language, movie_id, append_to_response } = params;
+		const { language = this.defaultOptions.language, movie_id, ...rest } = params;
 		const endpoint = this.moviePath(movie_id);
-		return this.client.request(endpoint, { language, append_to_response });
+		return this.client.request(endpoint, this.injectImageLanguageForAppends({ language, ...rest }));
 	}
 
 	/**

--- a/packages/tmdb/src/endpoints/tv_episodes.ts
+++ b/packages/tmdb/src/endpoints/tv_episodes.ts
@@ -37,15 +37,18 @@ export class TVEpisodesAPI extends TMDBAPIBase {
 	 * @param episode_number The number of the episode within the season
 	 * @param append_to_response A comma-separated list of the fields to include in the response.
 	 * @param language The language to use for the response.
+	 * @param include_image_language Extra languages for an appended `images` block. `language`
+	 * alone filters it down to that language's tagged stills only — pass `["null", "en"]` or
+	 * similar to get untagged stills back.
 	 * @returns A promise that resolves to the TV episode .
 	 * @reference https://developer.themoviedb.org/reference/tv-episode-details
 	 */
 	async details<T extends readonly TVEpisodeAppendToResponseNamespace[] = []>(
 		params: TVEpisodeDetailsParams & { append_to_response?: T[number] | T },
 	): Promise<T extends [] ? TVEpisode : TVEpisodeDetailsWithAppends<T>> {
-		const { language = this.defaultOptions.language, append_to_response, ...rest } = params;
-		const endpoint = this.episodePath(rest);
-		return this.client.request(endpoint, { language, append_to_response });
+		const { language = this.defaultOptions.language, series_id, season_number, episode_number, ...rest } = params;
+		const endpoint = this.episodePath({ series_id, season_number, episode_number });
+		return this.client.request(endpoint, this.injectImageLanguageForAppends({ language, ...rest }));
 	}
 
 	/**

--- a/packages/tmdb/src/endpoints/tv_seasons.ts
+++ b/packages/tmdb/src/endpoints/tv_seasons.ts
@@ -41,15 +41,18 @@ export class TVSeasonsAPI extends TMDBAPIBase {
 	 * @param season_number The season number within the TV show.
 	 * @param append_to_response A comma-separated list of the fields to include in the response.
 	 * @param language The language to use for the response.
+	 * @param include_image_language Extra languages for an appended `images` block. `language`
+	 * alone filters it down to that language's tagged images only — pass `["null", "en"]` or
+	 * similar to get untagged and English-tagged posters back.
 	 * @returns A promise that resolves to the TV season details.
 	 * @reference https://developer.themoviedb.org/reference/tv-season-details
 	 */
 	async details<T extends readonly TVSeasonAppendToResponseNamespace[] = []>(
 		params: Omit<TVSeasonDetailsParams, "append_to_response"> & { append_to_response?: T },
 	): Promise<T extends [] ? TVSeason : TVSeasonDetailsWithAppends<T>> {
-		const { language = this.defaultOptions.language, append_to_response, ...rest } = params;
-		const endpoint = this.seasonPath(rest);
-		return this.client.request(endpoint, { language, append_to_response });
+		const { language = this.defaultOptions.language, series_id, season_number, ...rest } = params;
+		const endpoint = this.seasonPath({ series_id, season_number });
+		return this.client.request(endpoint, this.injectImageLanguageForAppends({ language, ...rest }));
 	}
 
 	/**

--- a/packages/tmdb/src/endpoints/tv_series.ts
+++ b/packages/tmdb/src/endpoints/tv_series.ts
@@ -50,6 +50,9 @@ export class TVSeriesAPI extends TMDBAPIBase {
 	 * @param series_id The ID of the TV series.
 	 * @param append_to_response A comma-separated list of the fields to include in the response.
 	 * @param language The language to use for the response.
+	 * @param include_image_language Extra languages for an appended `images` block. `language`
+	 * alone filters it down to that language's tagged images only, which drops every logo and
+	 * untagged backdrop — pass `["null", "en"]` or similar to get them back.
 	 * @returns A promise that resolves to the TV series details.
 	 * @reference https://developer.themoviedb.org/reference/tv-series-details
 	 */
@@ -58,7 +61,7 @@ export class TVSeriesAPI extends TMDBAPIBase {
 	): Promise<T extends [] ? TVSeriesDetails : TVDetailsWithAppends<T>> {
 		const { language = this.defaultOptions.language, series_id, ...rest } = params;
 		const endpoint = this.seriesPath(series_id);
-		return this.client.request(endpoint, { language, ...rest });
+		return this.client.request(endpoint, this.injectImageLanguageForAppends({ language, ...rest }));
 	}
 
 	/**

--- a/packages/tmdb/src/tests/base/include-image-language-appends.test.ts
+++ b/packages/tmdb/src/tests/base/include-image-language-appends.test.ts
@@ -6,6 +6,7 @@ import { PeopleAPI } from "../../endpoints/people";
 import { TVEpisodesAPI } from "../../endpoints/tv_episodes";
 import { TVSeasonsAPI } from "../../endpoints/tv_seasons";
 import { TVSeriesAPI } from "../../endpoints/tv_series";
+import { TMDBOptions } from "../../types/config";
 
 /**
  * `include_image_language` is required to get logos, untagged backdrops or textless
@@ -107,15 +108,15 @@ describe("include_image_language on details() with append_to_response", () => {
 	});
 
 	describe("auto_include_image_language", () => {
-		const options = {
+		const options: TMDBOptions = {
 			images: {
 				auto_include_image_language: true,
 				image_language_priority: { posters: ["it", "null", "*"], backdrops: ["en"] },
 			},
-		} as const;
+		};
 
 		it("is derived for a details call that appends images", async () => {
-			await new MoviesAPI(clientMock, { ...options }).details({
+			await new MoviesAPI(clientMock, options).details({
 				movie_id: 550,
 				append_to_response: ["images", "credits"],
 			});
@@ -124,7 +125,7 @@ describe("include_image_language on details() with append_to_response", () => {
 		});
 
 		it("is derived when append_to_response is the bare string form", async () => {
-			await new MoviesAPI(clientMock, { ...options }).details({ movie_id: 550, append_to_response: "images" });
+			await new MoviesAPI(clientMock, options).details({ movie_id: 550, append_to_response: "images" });
 			expect(params().include_image_language).toEqual(expect.arrayContaining(["it", "null", "en"]));
 		});
 
@@ -135,7 +136,7 @@ describe("include_image_language on details() with append_to_response", () => {
 		// used to silently skip the injection.
 		describe("comma-separated append_to_response", () => {
 			it("is derived from a joined string", async () => {
-				await new MoviesAPI(clientMock, { ...options }).details({
+				await new MoviesAPI(clientMock, options).details({
 					movie_id: 550,
 					append_to_response: "credits,images" as never,
 				});
@@ -143,7 +144,7 @@ describe("include_image_language on details() with append_to_response", () => {
 			});
 
 			it("tolerates whitespace around the entries", async () => {
-				await new MoviesAPI(clientMock, { ...options }).details({
+				await new MoviesAPI(clientMock, options).details({
 					movie_id: 550,
 					append_to_response: " credits , images " as never,
 				});
@@ -151,7 +152,7 @@ describe("include_image_language on details() with append_to_response", () => {
 			});
 
 			it("is derived from an array holding a joined string", async () => {
-				await new MoviesAPI(clientMock, { ...options }).details({
+				await new MoviesAPI(clientMock, options).details({
 					movie_id: 550,
 					append_to_response: ["credits,images"] as never,
 				});
@@ -159,7 +160,7 @@ describe("include_image_language on details() with append_to_response", () => {
 			});
 
 			it("is not derived when the joined string has no images entry", async () => {
-				await new MoviesAPI(clientMock, { ...options }).details({
+				await new MoviesAPI(clientMock, options).details({
 					movie_id: 550,
 					append_to_response: "credits,videos" as never,
 				});
@@ -167,7 +168,7 @@ describe("include_image_language on details() with append_to_response", () => {
 			});
 
 			it("does not match a namespace that merely contains 'images'", async () => {
-				await new MoviesAPI(clientMock, { ...options }).details({
+				await new MoviesAPI(clientMock, options).details({
 					movie_id: 550,
 					append_to_response: "images_extra,credits" as never,
 				});
@@ -175,7 +176,7 @@ describe("include_image_language on details() with append_to_response", () => {
 			});
 
 			it("forwards the joined string to the client untouched", async () => {
-				await new MoviesAPI(clientMock, { ...options }).details({
+				await new MoviesAPI(clientMock, options).details({
 					movie_id: 550,
 					append_to_response: "credits,images" as never,
 				});
@@ -184,17 +185,17 @@ describe("include_image_language on details() with append_to_response", () => {
 		});
 
 		it("is not derived when the call does not append images", async () => {
-			await new MoviesAPI(clientMock, { ...options }).details({ movie_id: 550, append_to_response: ["credits"] });
+			await new MoviesAPI(clientMock, options).details({ movie_id: 550, append_to_response: ["credits"] });
 			expect(params().include_image_language).toBeUndefined();
 		});
 
 		it("is not derived when there is no append_to_response at all", async () => {
-			await new MoviesAPI(clientMock, { ...options }).details({ movie_id: 550 });
+			await new MoviesAPI(clientMock, options).details({ movie_id: 550 });
 			expect(params().include_image_language).toBeUndefined();
 		});
 
 		it("does not override an explicit call-site value", async () => {
-			await new MoviesAPI(clientMock, { ...options }).details({
+			await new MoviesAPI(clientMock, options).details({
 				movie_id: 550,
 				append_to_response: ["images"],
 				include_image_language: ["fr", "null"],
@@ -203,13 +204,13 @@ describe("include_image_language on details() with append_to_response", () => {
 		});
 
 		it("applies to tv, season and episode details too", async () => {
-			await new TVSeriesAPI(clientMock, { ...options }).details({ series_id: 1396, append_to_response: ["images"] });
-			await new TVSeasonsAPI(clientMock, { ...options }).details({
+			await new TVSeriesAPI(clientMock, options).details({ series_id: 1396, append_to_response: ["images"] });
+			await new TVSeasonsAPI(clientMock, options).details({
 				series_id: 1396,
 				season_number: 1,
 				append_to_response: ["images"],
 			});
-			await new TVEpisodesAPI(clientMock, { ...options }).details({
+			await new TVEpisodesAPI(clientMock, options).details({
 				series_id: 1396,
 				season_number: 1,
 				episode_number: 1,
@@ -221,7 +222,7 @@ describe("include_image_language on details() with append_to_response", () => {
 		});
 
 		it("is not derived for people.details — TMDB profile images carry no language tag", async () => {
-			await new PeopleAPI(clientMock, { ...options }).details({ person_id: 287, append_to_response: ["images"] });
+			await new PeopleAPI(clientMock, options).details({ person_id: 287, append_to_response: ["images"] });
 			expect(params().include_image_language).toBeUndefined();
 		});
 	});

--- a/packages/tmdb/src/tests/base/include-image-language-appends.test.ts
+++ b/packages/tmdb/src/tests/base/include-image-language-appends.test.ts
@@ -128,6 +128,61 @@ describe("include_image_language on details() with append_to_response", () => {
 			expect(params().include_image_language).toEqual(expect.arrayContaining(["it", "null", "en"]));
 		});
 
+		// TMDB accepts append_to_response as a comma-separated list and the endpoint JSDoc
+		// documents it that way, so a joined string has to behave like the array form.
+		// The param types only allow single namespaces or arrays of them, so reaching this
+		// path takes a cast — but JS consumers and `as never` escape hatches do it, and it
+		// used to silently skip the injection.
+		describe("comma-separated append_to_response", () => {
+			it("is derived from a joined string", async () => {
+				await new MoviesAPI(clientMock, { ...options }).details({
+					movie_id: 550,
+					append_to_response: "credits,images" as never,
+				});
+				expect(params().include_image_language).toEqual(expect.arrayContaining(["it", "null", "en"]));
+			});
+
+			it("tolerates whitespace around the entries", async () => {
+				await new MoviesAPI(clientMock, { ...options }).details({
+					movie_id: 550,
+					append_to_response: " credits , images " as never,
+				});
+				expect(params().include_image_language).toEqual(expect.arrayContaining(["it", "null", "en"]));
+			});
+
+			it("is derived from an array holding a joined string", async () => {
+				await new MoviesAPI(clientMock, { ...options }).details({
+					movie_id: 550,
+					append_to_response: ["credits,images"] as never,
+				});
+				expect(params().include_image_language).toEqual(expect.arrayContaining(["it", "null", "en"]));
+			});
+
+			it("is not derived when the joined string has no images entry", async () => {
+				await new MoviesAPI(clientMock, { ...options }).details({
+					movie_id: 550,
+					append_to_response: "credits,videos" as never,
+				});
+				expect(params().include_image_language).toBeUndefined();
+			});
+
+			it("does not match a namespace that merely contains 'images'", async () => {
+				await new MoviesAPI(clientMock, { ...options }).details({
+					movie_id: 550,
+					append_to_response: "images_extra,credits" as never,
+				});
+				expect(params().include_image_language).toBeUndefined();
+			});
+
+			it("forwards the joined string to the client untouched", async () => {
+				await new MoviesAPI(clientMock, { ...options }).details({
+					movie_id: 550,
+					append_to_response: "credits,images" as never,
+				});
+				expect(params().append_to_response).toBe("credits,images");
+			});
+		});
+
 		it("is not derived when the call does not append images", async () => {
 			await new MoviesAPI(clientMock, { ...options }).details({ movie_id: 550, append_to_response: ["credits"] });
 			expect(params().include_image_language).toBeUndefined();

--- a/packages/tmdb/src/tests/base/include-image-language-appends.test.ts
+++ b/packages/tmdb/src/tests/base/include-image-language-appends.test.ts
@@ -1,0 +1,215 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ApiClient } from "../../client";
+import { MoviesAPI } from "../../endpoints/movies";
+import { PeopleAPI } from "../../endpoints/people";
+import { TVEpisodesAPI } from "../../endpoints/tv_episodes";
+import { TVSeasonsAPI } from "../../endpoints/tv_seasons";
+import { TVSeriesAPI } from "../../endpoints/tv_series";
+
+/**
+ * `include_image_language` is required to get logos, untagged backdrops or textless
+ * posters out of an appended `images` block — `language` alone filters the block down
+ * to that language's tagged images. It used to be destructured away by the details()
+ * methods, so the value never reached the query string and the failure was silent.
+ */
+describe("include_image_language on details() with append_to_response", () => {
+	let clientMock: ApiClient;
+
+	const params = (index = 0) => (clientMock.request as ReturnType<typeof vi.fn>).mock.calls[index][1];
+
+	beforeEach(() => {
+		clientMock = new ApiClient("valid_access_token");
+		clientMock.request = vi.fn();
+	});
+
+	describe("explicit call-site value is forwarded", () => {
+		const include_image_language = ["null", "en"] as const;
+
+		it("movies.details", async () => {
+			await new MoviesAPI(clientMock).details({
+				movie_id: 550,
+				language: "it-IT",
+				append_to_response: ["images"],
+				include_image_language: [...include_image_language],
+			});
+			expect(clientMock.request).toHaveBeenCalledWith("/movie/550", {
+				language: "it-IT",
+				append_to_response: ["images"],
+				include_image_language: ["null", "en"],
+			});
+		});
+
+		it("tv_series.details", async () => {
+			await new TVSeriesAPI(clientMock).details({
+				series_id: 1396,
+				language: "it-IT",
+				append_to_response: ["images"],
+				include_image_language: [...include_image_language],
+			});
+			expect(clientMock.request).toHaveBeenCalledWith("/tv/1396", {
+				language: "it-IT",
+				append_to_response: ["images"],
+				include_image_language: ["null", "en"],
+			});
+		});
+
+		it("tv_seasons.details", async () => {
+			await new TVSeasonsAPI(clientMock).details({
+				series_id: 1396,
+				season_number: 1,
+				language: "it-IT",
+				append_to_response: ["images"],
+				include_image_language: [...include_image_language],
+			});
+			expect(clientMock.request).toHaveBeenCalledWith("/tv/1396/season/1", {
+				language: "it-IT",
+				append_to_response: ["images"],
+				include_image_language: ["null", "en"],
+			});
+		});
+
+		it("tv_episodes.details", async () => {
+			await new TVEpisodesAPI(clientMock).details({
+				series_id: 1396,
+				season_number: 1,
+				episode_number: 1,
+				language: "it-IT",
+				append_to_response: ["images"],
+				include_image_language: [...include_image_language],
+			});
+			expect(clientMock.request).toHaveBeenCalledWith("/tv/1396/season/1/episode/1", {
+				language: "it-IT",
+				append_to_response: ["images"],
+				include_image_language: ["null", "en"],
+			});
+		});
+	});
+
+	describe("path params never leak into the query string", () => {
+		it("tv_seasons.details keeps series_id and season_number in the path only", async () => {
+			await new TVSeasonsAPI(clientMock).details({ series_id: 1396, season_number: 1 });
+			expect(params()).not.toHaveProperty("series_id");
+			expect(params()).not.toHaveProperty("season_number");
+		});
+
+		it("tv_episodes.details keeps all three path params in the path only", async () => {
+			await new TVEpisodesAPI(clientMock).details({ series_id: 1396, season_number: 1, episode_number: 1 });
+			expect(params()).not.toHaveProperty("series_id");
+			expect(params()).not.toHaveProperty("season_number");
+			expect(params()).not.toHaveProperty("episode_number");
+		});
+
+		it("movies.details keeps movie_id in the path only", async () => {
+			await new MoviesAPI(clientMock).details({ movie_id: 550 });
+			expect(params()).not.toHaveProperty("movie_id");
+		});
+	});
+
+	describe("auto_include_image_language", () => {
+		const options = {
+			images: {
+				auto_include_image_language: true,
+				image_language_priority: { posters: ["it", "null", "*"], backdrops: ["en"] },
+			},
+		} as const;
+
+		it("is derived for a details call that appends images", async () => {
+			await new MoviesAPI(clientMock, { ...options }).details({
+				movie_id: 550,
+				append_to_response: ["images", "credits"],
+			});
+			expect(params().include_image_language).toEqual(expect.arrayContaining(["it", "null", "en"]));
+			expect(params().include_image_language).not.toContain("*");
+		});
+
+		it("is derived when append_to_response is the bare string form", async () => {
+			await new MoviesAPI(clientMock, { ...options }).details({ movie_id: 550, append_to_response: "images" });
+			expect(params().include_image_language).toEqual(expect.arrayContaining(["it", "null", "en"]));
+		});
+
+		it("is not derived when the call does not append images", async () => {
+			await new MoviesAPI(clientMock, { ...options }).details({ movie_id: 550, append_to_response: ["credits"] });
+			expect(params().include_image_language).toBeUndefined();
+		});
+
+		it("is not derived when there is no append_to_response at all", async () => {
+			await new MoviesAPI(clientMock, { ...options }).details({ movie_id: 550 });
+			expect(params().include_image_language).toBeUndefined();
+		});
+
+		it("does not override an explicit call-site value", async () => {
+			await new MoviesAPI(clientMock, { ...options }).details({
+				movie_id: 550,
+				append_to_response: ["images"],
+				include_image_language: ["fr", "null"],
+			});
+			expect(params().include_image_language).toEqual(["fr", "null"]);
+		});
+
+		it("applies to tv, season and episode details too", async () => {
+			await new TVSeriesAPI(clientMock, { ...options }).details({ series_id: 1396, append_to_response: ["images"] });
+			await new TVSeasonsAPI(clientMock, { ...options }).details({
+				series_id: 1396,
+				season_number: 1,
+				append_to_response: ["images"],
+			});
+			await new TVEpisodesAPI(clientMock, { ...options }).details({
+				series_id: 1396,
+				season_number: 1,
+				episode_number: 1,
+				append_to_response: ["images"],
+			});
+			for (const index of [0, 1, 2]) {
+				expect(params(index).include_image_language).toEqual(expect.arrayContaining(["it", "null", "en"]));
+			}
+		});
+
+		it("is not derived for people.details — TMDB profile images carry no language tag", async () => {
+			await new PeopleAPI(clientMock, { ...options }).details({ person_id: 287, append_to_response: ["images"] });
+			expect(params().include_image_language).toBeUndefined();
+		});
+	});
+});
+
+describe("include_image_language reaches the request URL", () => {
+	const originalFetch = globalThis.fetch;
+
+	beforeEach(() => {
+		globalThis.fetch = vi.fn().mockResolvedValue({
+			ok: true,
+			status: 200,
+			statusText: "OK",
+			url: "https://api.themoviedb.org/3/movie/550",
+			headers: { get: () => null },
+			json: async () => ({}),
+		});
+	});
+
+	afterEach(() => {
+		globalThis.fetch = originalFetch;
+		vi.restoreAllMocks();
+	});
+
+	const calledUrl = () => (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+
+	it("serializes the array as a comma-separated list", async () => {
+		// `test_api_key_v3` is a mock — fetch is stubbed, so no real credential is involved.
+		await new MoviesAPI("test_api_key_v3").details({
+			movie_id: 550,
+			language: "it-IT",
+			append_to_response: ["images"],
+			include_image_language: ["null", "en"],
+		});
+		expect(decodeURIComponent(calledUrl())).toContain("include_image_language=null,en");
+	});
+
+	it("omits the param entirely when it is not given", async () => {
+		await new MoviesAPI("test_api_key_v3").details({
+			movie_id: 550,
+			language: "it-IT",
+			append_to_response: ["images"],
+		});
+		expect(calledUrl()).not.toContain("include_image_language");
+	});
+});

--- a/packages/tmdb/src/types/config/images.ts
+++ b/packages/tmdb/src/types/config/images.ts
@@ -70,9 +70,7 @@ export type DefaultImageSizesConfig = {
  * // Prefer textless posters → English → any fallback
  * { posters: ["null", "en", "*"] }
  */
-export type ImageLanguagePriorityConfig = Partial<
-	Record<"backdrops" | "logos" | "posters" | "profiles" | "stills", string[]>
->;
+export type ImageLanguagePriorityConfig = Partial<Record<"backdrops" | "logos" | "posters" | "profiles" | "stills", string[]>>;
 
 /**
  * Fallback URL(s) used when an image path field is absent (`null` / `undefined`) in a TMDB
@@ -134,11 +132,18 @@ export type ImagesConfig = {
 	 * request — so TMDB returns the language variants that the priority config expects
 	 * to sort.
 	 *
+	 * Also applies to `.details()` calls that request an images block via
+	 * `append_to_response: ["images"]`. It is *not* injected into details calls that
+	 * don't append images, since TMDB would ignore it there.
+	 *
 	 * The injected value is the union of all language codes across all configured
 	 * collections, with `"*"` excluded (it has no meaning as an HTTP parameter).
 	 * An explicit `include_image_language` on the call site always takes precedence.
 	 *
 	 * Requires `image_language_priority` to be set; has no effect without it.
+	 *
+	 * Note: `person.images()` and person details take no `include_image_language` —
+	 * TMDB profile images carry no language tag — so this setting does not affect them.
 	 *
 	 * @default false
 	 *

--- a/packages/tmdb/src/types/movies.ts
+++ b/packages/tmdb/src/types/movies.ts
@@ -343,6 +343,16 @@ type MovieBaseParam = { movie_id: number };
 export type MovieDetailsParams = Prettify<
 	MovieBaseParam & {
 		append_to_response?: MovieAppendToResponseNamespace | MovieAppendToResponseNamespace[];
+		/**
+		 * Languages to include images for in an appended `images` block. Pass an array — it is
+		 * serialized as a comma-separated list (e.g. `["en", "null"]`). Use `"null"` to include
+		 * untagged images.
+		 *
+		 * Only meaningful together with `append_to_response: ["images"]`. Without it, `language`
+		 * acts as a filter on the appended block and TMDB returns only images tagged with that
+		 * language — no logos (which are always language-tagged) and no untagged backdrops.
+		 */
+		include_image_language?: (Language | "null")[];
 	} & WithParams<"language">
 >;
 

--- a/packages/tmdb/src/types/tv-episodes.ts
+++ b/packages/tmdb/src/types/tv-episodes.ts
@@ -109,7 +109,19 @@ export type TVEpisodeChangesParams = TVEpisodeId & Prettify<WithParams<"page"> &
  * Parameters for fetching TV episode details with optional additional data appended.
  */
 export type TVEpisodeDetailsParams = Prettify<
-	TVEpisodeBaseParams & { append_to_response?: TVEpisodeAppendToResponseNamespace[] } & WithParams<"language">
+	TVEpisodeBaseParams & {
+		append_to_response?: TVEpisodeAppendToResponseNamespace[];
+		/**
+		 * Languages to include images for in an appended `images` block. Pass an array — it is
+		 * serialized as a comma-separated list (e.g. `["en", "null"]`). Use `"null"` to include
+		 * untagged images.
+		 *
+		 * Only meaningful together with `append_to_response: ["images"]`. Without it, `language`
+		 * acts as a filter on the appended block and TMDB returns only stills tagged with that
+		 * language — episode stills are mostly untagged, so the block usually comes back empty.
+		 */
+		include_image_language?: (Language | "null")[];
+	} & WithParams<"language">
 >;
 
 /** Parameters for tv episode credits endpoint */

--- a/packages/tmdb/src/types/tv-seasons.ts
+++ b/packages/tmdb/src/types/tv-seasons.ts
@@ -155,7 +155,19 @@ export type TVSeasonVideos = VideoResults;
 
 /** Parameters for the season details endpoint. */
 export type TVSeasonDetailsParams = Prettify<
-	TVSeasonBaseParams & { append_to_response?: TVSeasonAppendToResponseNamespace[] } & WithParams<"language">
+	TVSeasonBaseParams & {
+		append_to_response?: TVSeasonAppendToResponseNamespace[];
+		/**
+		 * Languages to include images for in an appended `images` block. Pass an array — it is
+		 * serialized as a comma-separated list (e.g. `["en", "null"]`). Use `"null"` to include
+		 * untagged images.
+		 *
+		 * Only meaningful together with `append_to_response: ["images"]`. Without it, `language`
+		 * acts as a filter on the appended block and TMDB returns only posters tagged with that
+		 * language.
+		 */
+		include_image_language?: (Language | "null")[];
+	} & WithParams<"language">
 >;
 
 /** Parameters for the season aggregate credits endpoint. */

--- a/packages/tmdb/src/types/tv-series.ts
+++ b/packages/tmdb/src/types/tv-series.ts
@@ -200,10 +200,9 @@ export type TVAppendableMap = {
  * TV show details with additional appended data based on the requested namespaces.
  * @template T - Array of append-to-response namespace keys to include
  */
-export type TVDetailsWithAppends<T extends readonly TVAppendToResponseNamespace[]> =
-	TVSeriesDetails & {
-		[K in T[number]]: TVAppendableMap[K];
-	};
+export type TVDetailsWithAppends<T extends readonly TVAppendToResponseNamespace[]> = TVSeriesDetails & {
+	[K in T[number]]: TVAppendableMap[K];
+};
 
 // MARK: Aggreate Credits
 
@@ -516,7 +515,19 @@ export type TVSeriesListParams = Prettify<WithLanguagePage & { timezone?: Timezo
  * Parameters for fetching TV show details with optional additional data appended.
  */
 export type TVDetailsParams = Prettify<
-	TVBaseParam & { append_to_response?: TVAppendToResponseNamespace[] } & WithParams<"language">
+	TVBaseParam & {
+		append_to_response?: TVAppendToResponseNamespace[];
+		/**
+		 * Languages to include images for in an appended `images` block. Pass an array — it is
+		 * serialized as a comma-separated list (e.g. `["en", "null"]`). Use `"null"` to include
+		 * untagged images.
+		 *
+		 * Only meaningful together with `append_to_response: ["images"]`. Without it, `language`
+		 * acts as a filter on the appended block and TMDB returns only images tagged with that
+		 * language — no logos (which are always language-tagged) and no untagged backdrops.
+		 */
+		include_image_language?: (Language | "null")[];
+	} & WithParams<"language">
 >;
 
 /**


### PR DESCRIPTION
# Pull Request

## 📋 Description

Fixes the reported bug: `include_image_language` was unusable on `details()` calls that append an images block.

`include_image_language` is what makes an appended `images` block usable. With only `language` set, TMDB treats it as a filter on the appended block and returns just the images tagged with that language — which drops **every logo** (logos are always language-tagged) and **every untagged backdrop**. The SDK neither typed nor sent the parameter, and there was no error: an empty `logos` array is indistinguishable from a title that genuinely has no logo.

### Root cause — the endpoint layer, not the serializer

Three `details()` methods destructured a fixed set of keys and forwarded only those:

```ts
// endpoints/movies.ts — before
const { language = this.defaultOptions.language, movie_id, append_to_response } = params;
return this.client.request(endpoint, { language, append_to_response });
```

Anything else in `params` was discarded before it reached the client. `ApiClient.serializeParams` has **no whitelist** — it serializes whatever it is handed, comma-joining arrays — so nothing downstream was at fault.

The five details endpoints were not equally affected, which matters for anyone auditing this:

| Endpoint | Forwarded before? | Live effect before |
| --- | --- | --- |
| `movies.details` | ❌ dropped | 3 posters / 0 backdrops / 0 logos |
| `tv_series.details` | ✅ (`...rest`) | worked — type-only gap |
| `tv_seasons.details` | ❌ dropped | 2 posters |
| `tv_episodes.details` | ❌ dropped | 0 stills |
| `people.details` | ✅ (`...rest`) | n/a — TMDB ignores it |

### Changes

1. **Types** — `include_image_language?: (Language | "null")[]` added to `MovieDetailsParams`, `TVDetailsParams`, `TVSeasonDetailsParams`, `TVEpisodeDetailsParams`, with a doc comment explaining the `language`-as-filter trap.

2. **Forwarding** — `movies`/`tv_seasons`/`tv_episodes` `details()` now spread `...rest`. Path params (`movie_id`, `series_id`, `season_number`, `episode_number`) are destructured out explicitly so they don't leak into the query string — `tv_seasons`/`tv_episodes` previously passed the whole `rest` object to their path builders, so this needed care.

3. **`auto_include_image_language` now covers appends** — new `injectImageLanguageForAppends()` in `TMDBAPIBase`, called from all four `details()` methods. Without this, a consumer who configured `image_language_priority` + `auto_include_image_language` would still get empty logos on every append — the same silent failure in a different hat. It's gated on the request actually appending images, so details calls that don't ask for images keep a clean query string and unchanged cache/dedup keys.

### `PersonDetailsParams` deliberately excluded

The report listed it as affected. It isn't: TMDB profile images carry no language tag, `PersonImagesParams = PersonBaseParam` correctly omits the field, and `people.details` already forwards it — passing it returns 29 profiles either way. Adding the type would advertise a parameter that does nothing.

### Not breaking

Passing no `include_image_language` produces a byte-identical URL to before (`serializeParams` skips `undefined`). The only behavioural delta for existing code is that previously-discarded extra params on three `details()` methods now reach TMDB, which is the fix.

## ✅ Checklist

- [x] My code follows the code style of this project
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] All tests pass locally
- [x] I have linted and formatted the code using `pnpm lint` and `pnpm format`

## 🧪 How Has This Been Tested?

**16 new tests** in `src/tests/base/include-image-language-appends.test.ts`:

- Explicit call-site value forwarded, per endpoint (movie / TV / season / episode).
- Path params never leak into query params — regression guard for change #2.
- `auto_include_image_language`: derived when appending `images`; derived for the bare-string `append_to_response: "images"` form; **not** derived without an images append; not derived with no `append_to_response`; never overrides an explicit call-site value; applies to TV/season/episode; not applied to `people.details`.
- URL-level assertion (stubbed `fetch`): the array serializes to `include_image_language=null,en`, and the param is absent when not passed.

**Live API verification** — Fight Club (550) and Breaking Bad (1396), `language=it-IT`, `append_to_response=images`. SDK output compared against a raw `fetch` of the same URL; a dropped param shows up as a shape mismatch. Repro script in the linked issue.

```
endpoint             sdk before          sdk after           raw fetch           verdict
movies.details       3 / 0 / 0           68 / 87 / 23        68 / 87 / 23        fixed
tv_series.details    108 / 124 / 9       108 / 124 / 9       108 / 124 / 9       was already ok
tv_seasons.details   2 posters           27 posters          27 posters          fixed
tv_episodes.details  0 stills            6 stills            6 stills            fixed
people.details       29 profiles         29 profiles         29 profiles         n/a — param is a no-op
```

(`posters / backdrops / logos` for movie and TV.)

Full gates from `packages/tmdb`:

```
pnpm run typecheck   # clean
pnpm run test:unit   # 49 files, 719 tests passed (was 703)
pnpm run lint        # clean
pnpm run build       # clean
```

## 💬 Additional Notes

**Pre-existing drift failure, unrelated to this PR.** `pnpm run test:drift` fails one case, `movies.details+append`, on `changes.changes[].items[].value` — "Required type fields the API did NOT return". Reproduced on a clean `main` with these changes stashed, so it predates this branch. It looks like the same class of issue #137 addressed for `ChangeItem.value`/`original_value` (shape varies per change key, TMDB documents no schema): TMDB is now omitting `value` on some change items entirely. Worth a separate issue — happy to file it.

**Docs updated:** reference pages for all four `details()` endpoints get the new param row plus a warning callout with real before/after counts, the four `*DetailsParams` type tables get the field, and `getting-started/options/images.mdx` documents the widened `auto_include_image_language` scope and the person-images exception. `apps/docs` builds clean.

**Changelog** not touched — this repo adds entries at release time with the merged PR number.
