### PR TITLE
docs(types): document missing Person*CastCredit / Person*CrewCredit types

### DIFF
--- a/apps/docs/content/docs/types/people.mdx
+++ b/apps/docs/content/docs/types/people.mdx
@@ -23,9 +23,25 @@ import { TypeTable } from "fumadocs-ui/components/type-table";
 
 <AutoTypeTable path="people.ts" name="PersonMovieCredits" />
 
+### `PersonMovieCastCredit`
+
+<AutoTypeTable path="people.ts" name="PersonMovieCastCredit" />
+
+### `PersonMovieCrewCredit`
+
+<AutoTypeTable path="people.ts" name="PersonMovieCrewCredit" />
+
 ## `PersonTVCredits`
 
 <AutoTypeTable path="people.ts" name="PersonTVCredits" />
+
+### `PersonTVCastCredit`
+
+<AutoTypeTable path="people.ts" name="PersonTVCastCredit" />
+
+### `PersonTVCrewCredit`
+
+<AutoTypeTable path="people.ts" name="PersonTVCrewCredit" />
 
 ## `PersonCombinedCredits`
 

--- a/apps/docs/content/docs/types/people.mdx
+++ b/apps/docs/content/docs/types/people.mdx
@@ -31,6 +31,22 @@ import { TypeTable } from "fumadocs-ui/components/type-table";
 
 <AutoTypeTable path="people.ts" name="PersonCombinedCredits" />
 
+### `PersonCombinedCastCredit`
+
+A discriminated union of the `cast` items in `PersonCombinedCredits`. Each item includes a `media_type` field to distinguish between entity types.
+
+```ts
+type PersonCombinedCastCredit = (PersonMovieCastCredit & { media_type: "movie" }) | (PersonTVCastCredit & { media_type: "tv" });
+```
+
+### `PersonCombinedCrewCredit`
+
+A discriminated union of the `crew` items in `PersonCombinedCredits`. Each item includes a `media_type` field to distinguish between entity types.
+
+```ts
+type PersonCombinedCrewCredit = (PersonMovieCrewCredit & { media_type: "movie" }) | (PersonTVCrewCredit & { media_type: "tv" });
+```
+
 ## `PersonTaggedImages`
 
 <AutoTypeTable path="people.ts" name="PersonTaggedImages" />


### PR DESCRIPTION
## Summary
- `PersonCombinedCastCredit`, `PersonCombinedCrewCredit`, `PersonMovieCastCredit`, `PersonMovieCrewCredit`, `PersonTVCastCredit`, and `PersonTVCrewCredit` back the `cast`/`crew` arrays on `PersonMovieCredits`, `PersonTVCredits`, and `PersonCombinedCredits`, but had no entries on the types docs page.
- Adds `AutoTypeTable` sections for the four plain object types, and inline code blocks for the two discriminated unions (following the existing `MultiSearchResultItem` pattern in `types/search.mdx`, since `AutoTypeTable` can't render unions as a table).

## Test plan
- [x] `pnpm build` (includes `docs:build`) succeeds — `AutoTypeTable` resolves all six new type references without error
- [x] `pnpm typecheck` and `pnpm lint` pass
- [x] Manually diffed the rendered doc structure against existing sections for consistency